### PR TITLE
fix: bug in showing element in context

### DIFF
--- a/frontend/src/modules/Workplace/main/customHooks/useElemStyles.js
+++ b/frontend/src/modules/Workplace/main/customHooks/useElemStyles.js
@@ -29,14 +29,12 @@ const useElemStyles = ({ index, prediction }) => {
     }
 
     const handleTextElemStyle = () => {
-        if (workspace["focusedIndex"] == index && prediction  == "false") {
+        
+        if (workspace["focusedIndex"] == index && (prediction  == "false" || !prediction) ) {
             textElemStyle = classes["text_auto_focus"] 
         }
         else if(workspace["focusedIndex"] == index && prediction  == "true"){
             textElemStyle = classes["text_auto_focus_pred"] 
-        }
-        else if (prediction && prediction == "true") {
-            textElemStyle = classes["text_predict"]
         }
         else {
             textElemStyle = classes["text_normal"]


### PR DESCRIPTION
This commit includes:
1. Remove unused else if, as the logic for getting the prediction has changed.
2. Adding an additional condition for the prediction's falsy value to match the values that are coming from the backend API, which are string values in case of false or true.