### PR TITLE
Frontend refactor

### DIFF
--- a/frontend/src/modules/Workplace/__tests__/test_upperbar.js
+++ b/frontend/src/modules/Workplace/__tests__/test_upperbar.js
@@ -16,7 +16,7 @@
 import React from "react";
 import { screen, fireEvent } from "@testing-library/react";
 import { renderWithProviderAndRouter, createCategory } from "../../../utils/test-utils";
-import { initialState as initialWorkspaceState } from "../DataSlice";
+import { initialState as initialWorkspaceState } from "../redux/DataSlice";
 import UpperBar from '../upperbar/UpperBar'
 import { categoriesExample } from '../../../utils/test-utils'
 

--- a/frontend/src/modules/Workplace/__tests__/test_workspaceInfo.js
+++ b/frontend/src/modules/Workplace/__tests__/test_workspaceInfo.js
@@ -16,7 +16,7 @@
 import React from "react";
 import { screen } from "@testing-library/react";
 import { renderWithProviderAndRouter } from "../../../utils/test-utils";
-import { initialState as initialWorkspaceState } from "../DataSlice";
+import { initialState as initialWorkspaceState } from "../redux/DataSlice";
 import WorkspaceInfo from "../information/WorkspaceInfo";
 
 test("test that workspace information is displayed correctly", async () => {

--- a/frontend/src/modules/Workplace/index.jsx
+++ b/frontend/src/modules/Workplace/index.jsx
@@ -22,7 +22,7 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   setSearchInput,
   resetSearchResults,
-} from "./DataSlice.jsx";
+} from './redux/DataSlice';
 import WorkspaceInfo from "./information/WorkspaceInfo";
 import UpperBar from "./upperbar/UpperBar";
 import Backdrop from "@mui/material/Backdrop";
@@ -46,6 +46,7 @@ import {
   EVALUATION_TOOLTIP_MSG,
   sidebarOptionEnum
 } from "../../const";
+
 import useTogglePanel from "./sidebar/customHooks/useTogglePanel";
 import Drawer from "@mui/material/Drawer";
 import { PanelManager } from "./PanelManager";

--- a/frontend/src/modules/Workplace/information/FileTransferLabels/TransferLabelsDialog.jsx
+++ b/frontend/src/modules/Workplace/information/FileTransferLabels/TransferLabelsDialog.jsx
@@ -9,7 +9,7 @@ import {
 import { Box, Modal, TextField } from "@mui/material";
 import "./styles.css";
 import { useDispatch } from "react-redux";
-import { uploadLabels, downloadLabels } from "../../DataSlice";
+import { uploadLabels, downloadLabels } from "../../redux/DataSlice";
 
 export const UploadLabelsDialog = ({ open, setOpen }) => {
   const dispatch = useDispatch();

--- a/frontend/src/modules/Workplace/information/WorkspaceInfo.jsx
+++ b/frontend/src/modules/Workplace/information/WorkspaceInfo.jsx
@@ -25,7 +25,7 @@ import info_icon from '../../../assets/workspace/help.svg';
 import logout_icon from '../../../assets/workspace/logout.svg';
 import workspace_icon from '../../../assets/workspace/change_catalog.svg';
 import { useDispatch, useSelector } from 'react-redux';
-import { downloadLabels, uploadLabels, checkModelUpdate, setWorkspaceId } from '../DataSlice.jsx';
+import { downloadLabels, uploadLabels, checkModelUpdate, setWorkspaceId } from '../redux/DataSlice';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 import Tabs from '@mui/material/Tabs';
@@ -242,16 +242,14 @@ export default function WorkspaceInfo({workspaceId, setTutorialOpen, checkModelI
 
     // placeholder for finding documents stats
     let doc_stats = {
-        pos: Object.values(workspace.labelState).filter(function (d) { return d == 'pos' }).length,
-        neg: Object.values(workspace.labelState).filter(function (d) { return d == 'neg' }).length,
-        total: workspace.elements.length
+        pos: workspace.pos_label_num_doc,
+        neg: workspace.neg_label_num_doc,
     };
 
     // placeholder for finding workspace  stats
     let workspace_stats = {
         pos: workspace.pos_label_num,
         neg: workspace.neg_label_num,
-        total: workspace.documents.length * 10
     };
 
     const open_introSlides = function () {

--- a/frontend/src/modules/Workplace/information/WorkspaceInfo.jsx
+++ b/frontend/src/modules/Workplace/information/WorkspaceInfo.jsx
@@ -242,14 +242,14 @@ export default function WorkspaceInfo({workspaceId, setTutorialOpen, checkModelI
 
     // placeholder for finding documents stats
     let doc_stats = {
-        pos: workspace.pos_label_num_doc,
-        neg: workspace.neg_label_num_doc,
+        pos: workspace.labelCount.documentPos,
+        neg: workspace.labelCount.documentNeg
     };
 
     // placeholder for finding workspace  stats
     let workspace_stats = {
-        pos: workspace.pos_label_num,
-        neg: workspace.neg_label_num,
+        pos: workspace.labelCount.workspacePos,
+        neg: workspace.labelCount.workspaceNeg,
     };
 
     const open_introSlides = function () {

--- a/frontend/src/modules/Workplace/main/MainPanel.jsx
+++ b/frontend/src/modules/Workplace/main/MainPanel.jsx
@@ -118,7 +118,7 @@ const MainPanel = ({ handleKeyEvent, open }) => {
                   keyEventHandler={(e) => handleKeyEvent(e, len_elements)}
                   focusedState={workspace.focusedState}
                   index={index + firstPageIndex}
-                  element_id={element.id}
+                  elementURI={element.id}
                   prediction={element.model_predictions[workspace.curCategory]}
                   text={element['text']}
                 />

--- a/frontend/src/modules/Workplace/main/customHooks/useElemLabelState.js
+++ b/frontend/src/modules/Workplace/main/customHooks/useElemLabelState.js
@@ -13,171 +13,140 @@
     limitations under the License.
 */
 
-import { 
-    setElementLabel, 
-    checkStatus, 
-    setLabelState, 
-    increaseIdInBatch, 
-    setSearchLabelState, 
-    setNumLabel, 
-    setNumLabelGlobal, 
-    setRecommendToLabelState, 
-    setPosPredLabelState, 
-    setPosElemLabelState, 
-    setSuspiciousElemLabelState, 
-    setDisagreeElemLabelState, 
-    setContradictiveElemLabelState, 
-} from "../../redux/DataSlice";
-import { useDispatch, useSelector } from 'react-redux';
 import {
-    sidebarOptionEnum
-} from "../../../../const";
+  setElementLabel,
+  checkStatus,
+  setLabelState,
+  setSearchLabelState,
+  setRecommendToLabelState,
+  setPosElemLabelState,
+  setPosPredLabelState,
+  setEvaluationLabelState,
+  setSuspiciousElemLabelState,
+  setContradictiveElemLabelState,
+  updateDocumentLabelCountByDiff,
+} from "../../redux/DataSlice";
+import { useDispatch, useSelector } from "react-redux";
+import { sidebarOptionEnum } from "../../../../const";
+import { getBooleanLabel, getNewLabelState } from "../../../../utils/utils";
 
-const useElemLabelState = ({ index, element_id }) => {
+const useElemLabelState = ({ index, elementURI }) => {
+  const dispatch = useDispatch();
+  const labelState = useSelector((state) => state.workspace.labelState);
+  const activePanel = useSelector((state) => state.workspace.activePanel);
 
-    const workspace = useSelector(state => state.workspace)
-    const numLabel = useSelector(state => state.workspace.numLabel)
-    const numLabelGlobal = useSelector(state => state.workspace.numLabelGlobal)
-    const dispatch = useDispatch()
-    const activePanel = useSelector(state => state.workspace.activePanel)
-    let newStateMain = { ...workspace.labelState }
-    let newPanelLabelState ={}
-    let searchPanelIndex = 0
- 
-    const getSearchPanelIndex = (newPanelLabelState) =>{
-        return Object.keys(newPanelLabelState).filter((id) => {
-            let index = id.indexOf('-');
-            let arr = [id.slice(0, index), id.slice(index + 1)];
-            if (arr[1] ==element_id) {
-                return id
-            }
-        })
+  const searchLabelState = useSelector((state) => state.workspace.searchLabelState);
+  const recommendToLabelState = useSelector((state) => state.workspace.recommendToLabelState);
+  const posPredLabelState = useSelector((state) => state.workspace.posPredLabelState);
+  const posElemLabelState = useSelector((state) => state.workspace.posElemLabelState);
+  const suspiciousElemLabelState = useSelector((state) => state.workspace.suspiciousElemLabelState);
+  const contradictiveElemPairsLabelState = useSelector((state) => state.workspace.contradictiveElemPairsLabelState);
+  const evaluationLabelState = useSelector((state) => state.workspace.evaluation.labelState);
+
+  const curDocName = useSelector((state) => state.workspace.curDocName);
+
+  /**
+   * Find the labeled main element in the opened sidebar panel. If it doesn't exist returns null
+   * @param {The list of element label state that is going to be updated} newPanelLabelState
+   * @returns The sidebarElementURI or null
+   */
+  const getSearchPanelIndex = (newPanelLabelState) => {
+    for (let sidebarElementURI in newPanelLabelState) {
+      if (
+        elementURI ===
+        sidebarElementURI.slice(sidebarElementURI.indexOf("-") + 1)
+      ) {
+        return sidebarElementURI;
+      }
     }
+    return null;
+  };
 
-       if(activePanel == sidebarOptionEnum.SEARCH){
-        newPanelLabelState = { ...workspace.searchLabelState }
-        searchPanelIndex = getSearchPanelIndex(newPanelLabelState)
-       }
-       else if(activePanel == sidebarOptionEnum.LABEL_NEXT){
-        newPanelLabelState = { ...workspace.recommendToLabelState }
-        searchPanelIndex = getSearchPanelIndex(newPanelLabelState)
-       }
- 
-       else if(activePanel == sidebarOptionEnum.POSITIVE_PREDICTIONS){
-        newPanelLabelState = { ...workspace.posPredLabelState }
-        searchPanelIndex = getSearchPanelIndex(newPanelLabelState)
-       }
-
-       else if(activePanel == sidebarOptionEnum.POSITIVE_LABELS){
-        newPanelLabelState = { ...workspace.posElemLabelState }
-        searchPanelIndex = getSearchPanelIndex(newPanelLabelState)
-       }
-
-       else if(activePanel == sidebarOptionEnum.SUSPICIOUS_LABELS){
-        newPanelLabelState = { ...workspace.suspiciousElemLabelState }
-        searchPanelIndex = getSearchPanelIndex(newPanelLabelState)
-       }
-
-       else if(activePanel == sidebarOptionEnum.DISAGREEMENTS){
-        newPanelLabelState = { ...workspace.disagreeElemLabelState }
-        searchPanelIndex = getSearchPanelIndex(newPanelLabelState)
-       }
-
-       else if(activePanel == sidebarOptionEnum.CONTRADICTING_LABELS){
-        newPanelLabelState = { ...workspace.contradictiveElemPairsLabelState}
-        searchPanelIndex = getSearchPanelIndex(newPanelLabelState)
-       }
-
-       const updateLabelsState = (element_id, label, newPanelLabelState, newMainState) => {
-        dispatch(increaseIdInBatch())
-        dispatch(setElementLabel({ element_id: element_id, docid: workspace.curDocName, label: label })).then(() => {
-            dispatch(checkStatus())
-        })
-        if(activePanel === sidebarOptionEnum.SEARCH){
-            dispatch(setSearchLabelState(newPanelLabelState))
-        }
-        else if(activePanel === sidebarOptionEnum.LABEL_NEXT){
-            dispatch(setRecommendToLabelState(newPanelLabelState))
-        }
-        else if(activePanel === sidebarOptionEnum.POSITIVE_PREDICTIONS){
-            dispatch(setPosPredLabelState(newPanelLabelState))
-        }
-        else if(activePanel === sidebarOptionEnum.POSITIVE_LABELS){
-            dispatch(setPosElemLabelState(newPanelLabelState))
-        }
-        else if(activePanel === sidebarOptionEnum.SUSPICIOUS_LABELS){
-            dispatch(setSuspiciousElemLabelState(newPanelLabelState))
-        }
-        else if(activePanel === sidebarOptionEnum.DISAGREEMENTS){
-            dispatch(setDisagreeElemLabelState(newPanelLabelState))
-        }
-        else if(activePanel === sidebarOptionEnum.CONTRADICTING_LABELS){
-            dispatch(setContradictiveElemLabelState(newPanelLabelState))
-        }
-        dispatch(setLabelState(newMainState))
+  const getPanelElements = () => {
+    let newPanelLabelState;
+    let updatePanelLabelState;
+    switch (activePanel) {
+      case sidebarOptionEnum.SEARCH:
+        newPanelLabelState = { ...searchLabelState };
+        updatePanelLabelState = setSearchLabelState;
+        break;
+      case sidebarOptionEnum.LABEL_NEXT:
+        newPanelLabelState = { ...recommendToLabelState };
+        updatePanelLabelState = setRecommendToLabelState;
+        break;
+      case sidebarOptionEnum.POSITIVE_PREDICTIONS:
+        newPanelLabelState = { ...posPredLabelState };
+        updatePanelLabelState = setPosPredLabelState;
+        break;
+    case sidebarOptionEnum.POSITIVE_LABELS:
+        // elemLabelState update is managed in the setElementLabel.fulfilled action
+        break;
+    case sidebarOptionEnum.SUSPICIOUS_LABELS:
+        newPanelLabelState = { ...suspiciousElemLabelState };
+        updatePanelLabelState = setSuspiciousElemLabelState;
+        break;
+    case sidebarOptionEnum.CONTRADICTING_LABELS:
+        newPanelLabelState = { ...contradictiveElemPairsLabelState };
+        updatePanelLabelState = setContradictiveElemLabelState;
+        break;
+    case sidebarOptionEnum.EVALUATION:
+        newPanelLabelState = { ...evaluationLabelState };
+        updatePanelLabelState = setEvaluationLabelState;
+        break;
     }
+    return { newPanelLabelState, updatePanelLabelState };
+  };
 
+  /**
+   * This function is reponsible for managing main elements label state and updating
+   * the sidebar panel view if needed
+   * @param  {The label action: can be 'pos' or 'neg'} labelAction
+   */
+  const handleLabelState = (labelAction) => {
+    const { newPanelLabelState, updatePanelLabelState } = getPanelElements();
+    const searchPanelIndex = getSearchPanelIndex(newPanelLabelState);
 
-    const handlePosLabelState = () => {
-        
-        let label = "none"
-        let mainElemIndex = `L${index}`
+    let mainElemIndex = `L${index}`;
+    const newMainLabelState = { ...labelState };
 
-        if (newStateMain[mainElemIndex] == "pos") {
-            setNumLabel({ ...numLabel, "pos": numLabel['pos'] - 1 })
-            setNumLabelGlobal({ ...numLabelGlobal, "pos": numLabelGlobal['pos'] - 1 })
-            newStateMain[mainElemIndex] = label
-            newPanelLabelState[searchPanelIndex] = label
-        }
-        else {
-            if (newStateMain[mainElemIndex] == "neg") {
-                setNumLabel({ "pos": numLabel['pos'] + 1, "neg": numLabel['neg'] - 1 })
-                setNumLabelGlobal({ "pos": numLabelGlobal['pos'] + 1, "neg": numLabelGlobal['neg'] - 1 })
-            }
-            else {
-                setNumLabel({ ...numLabel, "pos": numLabel['pos'] + 1 })
-                setNumLabelGlobal({ ...numLabelGlobal, "pos": numLabelGlobal['pos'] + 1 })
-            }
-            newStateMain[mainElemIndex] = "pos"
-            newPanelLabelState[searchPanelIndex] = "pos"
-            label = "true"
-        }
-        updateLabelsState(element_id, label, newPanelLabelState, newStateMain)
-    }
+    const { documentLabelCountChange, newLabel } = getNewLabelState(
+      newMainLabelState[mainElemIndex],
+      labelAction
+    );
 
+    newMainLabelState[mainElemIndex] = newLabel;
 
-    const handleNegLabelState = () => {
-        let label = "none"
-        let mainElemIndex = `L${index}`
+    dispatch(updateDocumentLabelCountByDiff(documentLabelCountChange));
 
-        if (newStateMain[mainElemIndex] == "neg") {
-            setNumLabel({ ...numLabel, "neg": numLabel['neg'] - 1 })
-            setNumLabelGlobal({ ...numLabelGlobal, "neg": numLabelGlobal['neg'] - 1 })
-            newStateMain[mainElemIndex] = label
-            newPanelLabelState[searchPanelIndex] = label
-        }
-        else {
-            if (newStateMain[mainElemIndex] == "pos") {
-                setNumLabel({ "pos": numLabel['pos'] - 1, "neg": numLabel['neg'] + 1 })
-                setNumLabelGlobal({ "pos": numLabelGlobal['pos'] - 1, "neg": numLabelGlobal['neg'] + 1 })
-            }
-            else {
-                setNumLabel({ ...numLabel, "neg": numLabel['neg'] + 1 })
-                setNumLabelGlobal({ ...numLabelGlobal, "neg": numLabelGlobal['neg'] + 1 })
-            }
-            newStateMain[mainElemIndex] = "neg"
-            newPanelLabelState[searchPanelIndex] = "neg"
-            label = "false"
-        }
-        updateLabelsState(element_id, label, newPanelLabelState, newStateMain)
-    }
+    
+    dispatch(
+      setElementLabel({
+        element_id: elementURI,
+        docid: curDocName,
+        label: getBooleanLabel(newLabel),
+      })
+      ).then(() => {
+        dispatch(checkStatus());
+        dispatch(setLabelState(newMainLabelState));
+        if (searchPanelIndex !== null && newPanelLabelState && updatePanelLabelState) {
+          newPanelLabelState[searchPanelIndex] = newLabel;
+          dispatch(updatePanelLabelState(newPanelLabelState));
+      }
+    });
+  };
 
+  const handlePosLabelState = () => {
+    handleLabelState("pos");
+  };
 
+  const handleNegLabelState = () => {
+    handleLabelState("neg");
+  };
 
-    return {
-        handlePosLabelState,
-        handleNegLabelState,
-    }
+  return {
+    handlePosLabelState,
+    handleNegLabelState,
+  };
 };
 
 export default useElemLabelState;

--- a/frontend/src/modules/Workplace/main/customHooks/useElemLabelState.js
+++ b/frontend/src/modules/Workplace/main/customHooks/useElemLabelState.js
@@ -13,7 +13,8 @@
     limitations under the License.
 */
 
-import { setElementLabel, 
+import { 
+    setElementLabel, 
     checkStatus, 
     setLabelState, 
     increaseIdInBatch, 
@@ -25,7 +26,8 @@ import { setElementLabel,
     setPosElemLabelState, 
     setSuspiciousElemLabelState, 
     setDisagreeElemLabelState, 
-    setContradictiveElemLabelState } from '../../DataSlice';
+    setContradictiveElemLabelState, 
+} from "../../redux/DataSlice";
 import { useDispatch, useSelector } from 'react-redux';
 import {
     sidebarOptionEnum

--- a/frontend/src/modules/Workplace/main/customHooks/useFetchPrevNextDoc.js
+++ b/frontend/src/modules/Workplace/main/customHooks/useFetchPrevNextDoc.js
@@ -13,7 +13,7 @@
     limitations under the License.
 */
 
-import { fetchPrevDocElements, fetchNextDocElements, } from '../../DataSlice.jsx';
+import { fetchPrevDocElements, fetchNextDocElements, } from '../../redux/DataSlice';
 import { useDispatch, useSelector } from 'react-redux';
 
 const useFetchPrevNextDoc = () => {

--- a/frontend/src/modules/Workplace/redux/categorySlice.js
+++ b/frontend/src/modules/Workplace/redux/categorySlice.js
@@ -1,0 +1,166 @@
+/*
+    Copyright (c) 2022 IBM Corp.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { BASE_URL, WORKSPACE_API } from "../../../config";
+import { sidebarOptionEnum } from "../../../const";
+import { initialState } from './DataSlice'
+const getWorkspace_url = `${BASE_URL}/${WORKSPACE_API}`;
+
+
+export const createCategoryOnServer = createAsyncThunk('workspace/createCategoryOnServer', async (request, { getState }) => {
+
+    const state = getState()
+
+    const { category } = request
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(state.workspace.workspaceId)}/category`
+
+    const data = await fetch(url, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${state.authenticate.token}`
+        },
+        body: JSON.stringify({
+            'category_name': category,
+            'category_description': "",
+            'update_counter': true
+        }),
+        method: "POST"
+    }).then(response => response.json())
+
+    return data
+})
+
+export const deleteCategory = createAsyncThunk('workspace/deleteCategory', async (request, { getState }) => {
+
+    const state = getState()
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(state.workspace.workspaceId)}/category/${state.workspace.curCategory}`
+
+    const data = await fetch(url, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${state.authenticate.token}`
+        },
+        method: "DELETE"
+    }).then(response => response.json())
+
+    return data
+})
+
+export const editCategory = createAsyncThunk('workspace/editCategory', async ({newCategoryName, newCategoryDescription}, { getState }) => {
+
+    const state = getState()
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(state.workspace.workspaceId)}/category/${state.workspace.curCategory}`
+
+    const body = JSON.stringify({
+        category_name: newCategoryName,
+        category_description: newCategoryDescription
+    })
+
+    const data = await fetch(url, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${state.authenticate.token}`
+        },
+        body: body,
+        method: "PUT"
+    }).then(response => response.json())
+
+    return data
+})
+
+export const fetchCategories = createAsyncThunk('workspace/get_all_categories', async (request, { getState }) => {
+
+    const state = getState()
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(state.workspace.workspaceId)}/categories`
+
+    const data = await fetch(url, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${state.authenticate.token}`
+        },
+        method: "GET"
+    }).then(response => response.json())
+
+    return data
+})
+
+export const reducers = {
+    updateCurCategory(state, action) {
+        const c = action.payload
+        return {
+            ...state,
+            curCategory: c,
+            nextModelShouldBeTraining: false
+        }
+    },
+}
+
+export const extraReducers = {
+    [fetchCategories.fulfilled]: (state, action) => {
+        const data = action.payload
+
+        return {
+            ...state,
+            categories: data['categories']
+        }
+    },
+    [createCategoryOnServer.fulfilled]: (state, action) => {
+        // TODO: action.payload has an update_counter field that is not used, remove it
+        return {
+            ...state,
+            curCategory: action.payload.category_id.toString(),
+            categories: [...state.categories, action.payload],
+            nextModelShouldBeTraining: false
+        }
+    },
+    [deleteCategory.pending]: (state, action) => {
+        return {
+            ...state,
+            deletingCategory: true
+        }
+    },
+    [deleteCategory.fulfilled]: (state, action) => {
+        return {
+            ...initialState,
+            curDocName: state.curDocName,
+            documents: state.documents,
+            elements: state.elements,
+            deletingCategory: false,
+            categories: state.categories.filter(c => c.category_id != state.curCategory),
+            activePanel: sidebarOptionEnum.SEARCH,
+            workspaceId: state.workspaceId
+        }
+    },
+    [editCategory.fulfilled]: (state, action) => {
+        const { category_name, category_description } = action.payload;
+        return {
+          ...state,
+          categories: state.categories.map((c) =>
+            c.category_id == state.curCategory
+              ? {
+                  ...c,
+                  category_name,
+                  category_description,
+                }
+              : c
+          ),
+        };
+    },
+}

--- a/frontend/src/modules/Workplace/redux/documentSlice.js
+++ b/frontend/src/modules/Workplace/redux/documentSlice.js
@@ -1,0 +1,316 @@
+/*
+    Copyright (c) 2022 IBM Corp.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  BASE_URL,
+  WORKSPACE_API,
+} from "../../../config";
+import {
+  getCategoryQueryString,
+  getQueryParamsString,
+} from "../../../utils/utils";
+
+export { searchKeywords } from "./searchSlice";
+
+const getWorkspace_url = `${BASE_URL}/${WORKSPACE_API}`;
+
+export const fetchDocuments = createAsyncThunk(
+  "workspace/fetchDocuments",
+  async (request, { getState }) => {
+    const state = getState();
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/documents`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const fetchNextDocElements = createAsyncThunk(
+  "workspace/fetchNextDoc",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const curDocument =
+      state.workspace.documents[state.workspace.curDocId + 1]["document_id"];
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/document/${encodeURIComponent(curDocument)}${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const fetchPrevDocElements = createAsyncThunk(
+  "workspace/fetchPrevDoc",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const curDocument =
+      state.workspace.documents[state.workspace.curDocId - 1]["document_id"];
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/document/${encodeURIComponent(curDocument)}${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const fetchElements = createAsyncThunk(
+  "workspace/fetchElements",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const curDocument =
+      state.workspace.documents[state.workspace.curDocId]["document_id"];
+
+    var url = null;
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+    url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/document/${encodeURIComponent(curDocument)}${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const fetchCertainDocument = createAsyncThunk(
+  "workspace/fetchCertainDocument",
+  async (request, { getState }) => {
+    // if(!state.workspace.curCategory){
+    //     throw Error("No category was selected!")
+    // }
+    const state = getState();
+
+    const { docid, eid, switchStatus } = request;
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/document/${encodeURIComponent(docid)}${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => {
+      var data = response.json();
+      data["eid"] = eid;
+      return data;
+    });
+
+    return { data, eid, switchStatus };
+  }
+);
+
+export const reducers = {}
+  
+/**
+ * Parses the elements of a document extracting the user labels
+ * @param {list of elements of a document} elements 
+ * @param {The current selected category} curCategory 
+ * @returns 
+ */
+const parseElements = (elements, curCategory) => {
+  
+  var initialFocusedState = {};
+  
+  var initialLabelState = {};
+
+  var pos_label = 0;
+
+  var neg_label = 0;
+
+  for (const [i, element] of elements.entries()) {
+    initialFocusedState["L" + i] = false;
+    const userLabels = element['user_labels']
+    if (curCategory in userLabels) {
+      if (userLabels[curCategory] == "true") {
+        initialLabelState["L" + i] = "pos";
+        pos_label += 1;
+      } else if (
+        userLabels[curCategory] == "false"
+      ) {
+        initialLabelState["L" + i] = "neg";
+        neg_label += 1;
+      }
+    } else {
+      initialLabelState["L" + i] = "";
+    }
+  }
+  return {
+    initialFocusedState,
+    initialLabelState,
+    pos_label,
+    neg_label
+  }
+}
+
+export const extraReducers = {
+  [fetchElements.fulfilled]: (state, action) => {
+    const { elements } = action.payload;
+
+    const {
+      initialFocusedState,
+      initialLabelState,
+      pos_label,
+      neg_label
+    } = parseElements(elements, state.curCategory)
+
+    return {
+      ...state,
+      elements,
+      focusedState: initialFocusedState,
+      focusedIndex: null,
+      labelState: initialLabelState,
+      ready: true,
+      pos_label_num_doc: pos_label,
+      neg_label_num_doc: neg_label,
+    };
+  },
+  [fetchDocuments.fulfilled]: (state, action) => {
+    const { documents } = action.payload;
+    return {
+      ...state,
+      documents: documents,
+      curDocName: documents[0]["document_id"],
+      curDocId: 0,
+    };
+  },
+  [fetchNextDocElements.fulfilled]: (state, action) => {
+    const { elements } = action.payload;
+    const {
+      initialFocusedState,
+      initialLabelState,
+      pos_label,
+      neg_label
+    } = parseElements(elements, state.curCategory)
+
+    return {
+      ...state,
+      elements,
+      focusedState: initialFocusedState,
+      focusedIndex: null,
+      labelState: initialLabelState,
+      ready: true,
+      pos_label_num_doc: pos_label,
+      neg_label_num_doc: neg_label,
+
+      curDocId: state.curDocId + 1,
+      curDocName: state.documents[state.curDocId + 1]["document_id"],
+    };
+  },
+  [fetchPrevDocElements.fulfilled]: (state, action) => {
+    const { elements } = action.payload;
+    const {
+      initialFocusedState,
+      initialLabelState,
+      pos_label,
+      neg_label
+    } = parseElements(elements, state.curCategory)
+
+    return {
+      ...state,
+      elements,
+      focusedState: initialFocusedState,
+      focusedIndex: null,
+      labelState: initialLabelState,
+      ready: true,
+      pos_label_num_doc: pos_label,
+      neg_label_num_doc: neg_label,
+
+      curDocId: state.curDocId + 1,
+      curDocName: state.documents[state.curDocId - 1]["document_id"],
+    };
+  },
+  [fetchCertainDocument.fulfilled]: (state, action) => {
+    const { elements } = action.payload.data;
+
+    const {
+      initialFocusedState,
+      initialLabelState,
+      pos_label,
+      neg_label
+    } = parseElements(elements, state.curCategory)
+
+    const curDocument = elements[0]["docid"];
+    const newDocId = state.documents.findIndex(d => d['document_id'] === curDocument)
+
+    return {
+      ...state,
+      elements,
+      focusedState: initialFocusedState,
+      focusedIndex: null,
+      labelState: initialLabelState,
+      ready: true,
+      pos_label_num_doc: pos_label,
+      neg_label_num_doc: neg_label,
+
+      curDocId: newDocId,
+      curDocName: state["documents"][newDocId]["document_id"],
+    };
+  },
+};

--- a/frontend/src/modules/Workplace/redux/documentSlice.js
+++ b/frontend/src/modules/Workplace/redux/documentSlice.js
@@ -176,13 +176,11 @@ export const reducers = {}
  */
 const parseElements = (elements, curCategory) => {
   
-  var initialFocusedState = {};
-  
-  var initialLabelState = {};
+  let initialFocusedState = {};
+  let initialLabelState = {};
 
-  var pos_label = 0;
-
-  var neg_label = 0;
+  let documentPos = 0;
+  let documentNeg = 0;
 
   for (const [i, element] of elements.entries()) {
     initialFocusedState["L" + i] = false;
@@ -190,12 +188,12 @@ const parseElements = (elements, curCategory) => {
     if (curCategory in userLabels) {
       if (userLabels[curCategory] == "true") {
         initialLabelState["L" + i] = "pos";
-        pos_label += 1;
+        documentPos += 1;
       } else if (
         userLabels[curCategory] == "false"
       ) {
         initialLabelState["L" + i] = "neg";
-        neg_label += 1;
+        documentNeg += 1;
       }
     } else {
       initialLabelState["L" + i] = "";
@@ -204,8 +202,8 @@ const parseElements = (elements, curCategory) => {
   return {
     initialFocusedState,
     initialLabelState,
-    pos_label,
-    neg_label
+    documentPos,
+    documentNeg
   }
 }
 
@@ -216,8 +214,8 @@ export const extraReducers = {
     const {
       initialFocusedState,
       initialLabelState,
-      pos_label,
-      neg_label
+      documentPos,
+      documentNeg
     } = parseElements(elements, state.curCategory)
 
     return {
@@ -227,8 +225,11 @@ export const extraReducers = {
       focusedIndex: null,
       labelState: initialLabelState,
       ready: true,
-      pos_label_num_doc: pos_label,
-      neg_label_num_doc: neg_label,
+      labelCount: {
+        ...state.labelCount,
+        documentPos,
+        documentNeg
+      },
     };
   },
   [fetchDocuments.fulfilled]: (state, action) => {
@@ -245,8 +246,8 @@ export const extraReducers = {
     const {
       initialFocusedState,
       initialLabelState,
-      pos_label,
-      neg_label
+      documentPos,
+      documentNeg
     } = parseElements(elements, state.curCategory)
 
     return {
@@ -256,9 +257,11 @@ export const extraReducers = {
       focusedIndex: null,
       labelState: initialLabelState,
       ready: true,
-      pos_label_num_doc: pos_label,
-      neg_label_num_doc: neg_label,
-
+      labelCount: {
+        ...state.labelCount,
+        documentPos,
+        documentNeg
+      },
       curDocId: state.curDocId + 1,
       curDocName: state.documents[state.curDocId + 1]["document_id"],
     };
@@ -268,8 +271,8 @@ export const extraReducers = {
     const {
       initialFocusedState,
       initialLabelState,
-      pos_label,
-      neg_label
+      documentPos,
+      documentNeg
     } = parseElements(elements, state.curCategory)
 
     return {
@@ -279,8 +282,11 @@ export const extraReducers = {
       focusedIndex: null,
       labelState: initialLabelState,
       ready: true,
-      pos_label_num_doc: pos_label,
-      neg_label_num_doc: neg_label,
+      labelCount: {
+        ...state.labelCount,
+        documentPos,
+        documentNeg
+      },
 
       curDocId: state.curDocId + 1,
       curDocName: state.documents[state.curDocId - 1]["document_id"],
@@ -292,8 +298,8 @@ export const extraReducers = {
     const {
       initialFocusedState,
       initialLabelState,
-      pos_label,
-      neg_label
+      documentPos,
+      documentNeg
     } = parseElements(elements, state.curCategory)
 
     const curDocument = elements[0]["docid"];
@@ -306,8 +312,11 @@ export const extraReducers = {
       focusedIndex: null,
       labelState: initialLabelState,
       ready: true,
-      pos_label_num_doc: pos_label,
-      neg_label_num_doc: neg_label,
+      labelCount: {
+        ...state.labelCount,
+        documentPos,
+        documentNeg
+      },
 
       curDocId: newDocId,
       curDocName: state["documents"][newDocId]["document_id"],

--- a/frontend/src/modules/Workplace/redux/evaluationSlice.js
+++ b/frontend/src/modules/Workplace/redux/evaluationSlice.js
@@ -1,0 +1,208 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  getCategoryQueryString,
+  getQueryParamsString,
+  parseElements,
+} from "../../../utils/utils";
+import { BASE_URL, WORKSPACE_API } from "../../../config";
+
+const getWorkspace_url = `${BASE_URL}/${WORKSPACE_API}`;
+
+export const startEvaluation = createAsyncThunk(
+  "workspace/startEvaluation",
+  async (request, { dispatch }) => {
+    await dispatch(getEvaluationElements());
+  }
+);
+
+export const getEvaluationElements = createAsyncThunk(
+  "workspace/getEvaluationElements",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/precision_evaluation_elements${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+    return data;
+  }
+);
+
+export const getEvaluationResults = createAsyncThunk(
+  "workspace/getEvaluationResults",
+  async (changed_elements_count, { getState }) => {
+    const state = getState();
+
+    const ids = state.workspace.evaluation.elements.map((e) => e.id);
+    const iteration = state.workspace.model_version - 1;
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/precision_evaluation_elements${queryParams}`;
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      body: JSON.stringify({
+        ids,
+        iteration,
+        changed_elements_count,
+      }),
+      method: "POST",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const cancelEvaluation = createAsyncThunk(
+  "workspace/cancelEvaluation",
+  async (changed_elements_count, { getState }) => {
+    const state = getState();
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/cancel_precision_evaluation${queryParams}`;
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      body: JSON.stringify({
+        changed_elements_count,
+      }),
+      method: "POST",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const reducers = {
+  cleanEvaluationState(state, action) {
+    state.evaluation = {
+      isLoading: false,
+      isInProgress: false,
+      elements: [],
+      labelState: {},
+      initialLabelState: {},
+      lastScore: null,
+      scoreModelVersion: null,
+    };
+  },
+  setEvaluationLabelState(state, action) {
+    state.evaluation.labelState = action.payload;
+  },
+};
+
+export const extraReducers = {
+  [startEvaluation.fulfilled]: (state, action) => {
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        isInProgress: true,
+      },
+    };
+  },
+  [getEvaluationElements.fulfilled]: (state, action) => {
+    const { elements } = action.payload;
+    const { initialLabelState } = parseElements(
+      elements,
+      state.curCategory,
+      true
+    );
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        elements,
+        initialLabelState,
+        labelState: initialLabelState,
+        isLoading: false,
+      },
+    };
+  },
+  [getEvaluationElements.pending]: (state, action) => {
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        isLoading: true,
+      },
+    };
+  },
+  [getEvaluationElements.rejected]: (state, action) => {
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        isLoading: false,
+      },
+    };
+  },
+  [getEvaluationResults.fulfilled]: (state, action) => {
+    const { score } = action.payload;
+
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        isLoading: false,
+        isInProgress: false,
+        lastScore: score,
+        scoreModelVersion: state.model_version,
+      },
+    };
+  },
+  [getEvaluationResults.pending]: (state, action) => {
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        isLoading: true,
+      },
+    };
+  },
+  [getEvaluationResults.rejected]: (state, action) => {
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        isLoading: false,
+      },
+    };
+  },
+  [cancelEvaluation.fulfilled]: (state, action) => {
+    return {
+      ...state,
+      evaluation: {
+        ...state.evaluation,
+        isInProgress: false,
+        elements: [],
+        labelState: {},
+        initialLabelState: {},
+      },
+    };
+  },
+};

--- a/frontend/src/modules/Workplace/redux/labelSlice.js
+++ b/frontend/src/modules/Workplace/redux/labelSlice.js
@@ -1,0 +1,225 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  getCategoryQueryString,
+  getQueryParamsString,
+  parseElements,
+  handleError,
+} from "../../../utils/utils";
+import {
+  BASE_URL,
+  WORKSPACE_API,
+  DOWNLOAD_LABELS_API,
+  UPLOAD_LABELS_API,
+} from "../../../config";
+import fileDownload from "js-file-download";
+
+const getWorkspace_url = `${BASE_URL}/${WORKSPACE_API}`;
+
+export const downloadLabels = createAsyncThunk(
+  "workspace/downloadLabels",
+  async (request, { getState }) => {
+    const state = getState();
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/${DOWNLOAD_LABELS_API}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "text/csv;charset=UTF-8",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((res) => res.text());
+
+    return data;
+  }
+);
+
+export const uploadLabels = createAsyncThunk(
+  `workspace/uploadLabels`,
+  async (formData, { getState }) => {
+    const state = getState();
+    let headers = {
+      "Content-Type": "multipart/form-data",
+      Authorization: `Bearer ${state.authenticate.token}`,
+    };
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/${UPLOAD_LABELS_API}`;
+    const data = await fetch(url, {
+      method: "POST",
+      header: headers,
+      body: formData,
+    }).then((res) => res.json());
+    return data;
+  }
+);
+
+export const labelInfoGain = createAsyncThunk(
+  "workspace/labeled_info_gain",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/labeled_info_gain${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const setElementLabel = createAsyncThunk(
+  "workspace/set_element_label",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const { element_id, label, docid, update_counter } = request;
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/element/${encodeURIComponent(element_id)}${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      body: JSON.stringify({
+        category_id: state.workspace.curCategory,
+        value: label,
+        update_counter: update_counter,
+      }),
+      method: "PUT",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const reducers = {
+  setNumLabelGlobal(state, action) {
+    return {
+      ...state,
+      numLabelGlobal: action.payload,
+    };
+  },
+  setNumLabel(state, action) {
+    return {
+      ...state,
+      numLabel: action.payload,
+    };
+  },
+  setNumLabelGlobal(state, action) {
+    return {
+      ...state,
+      numLabelGlobal: action.payload,
+    };
+  },
+  setLabelState(state, action) {
+    const new_labeled_state = action.payload;
+
+    return {
+      ...state,
+      labelState: new_labeled_state,
+    };
+  },
+  updateDocumentLabelCountByDiff(state, action) {
+    const diff = action.payload;
+    return {
+      ...state,
+      labelCount: {
+        ...state.labelCount,
+        documentPos: state.labelCount.documentPos + diff.pos,
+        documentNeg: state.labelCount.documentNeg + diff.neg,
+      },
+    };
+  },
+};
+
+export const extraReducers = {
+  [downloadLabels.pending]: (state, action) => {
+    return {
+      ...state,
+      downloadingLabels: true,
+    };
+  },
+  [downloadLabels.fulfilled]: (state, action) => {
+    const data = action.payload;
+    const current = new Date();
+    const date = `${current.getDate()}/${
+      current.getMonth() + 1
+    }/${current.getFullYear()}`;
+    const fileName = `labeleddata_from_Label_Sleuth<${date}>.csv`;
+    fileDownload(data, fileName);
+    return {
+      ...state,
+      downloadingLabels: false,
+    };
+  },
+  [uploadLabels.pending]: (state, action) => {
+    return {
+      ...state,
+      uploadingLabels: true,
+    };
+  },
+  [uploadLabels.fulfilled]: (state, action) => {
+    return {
+      ...state,
+      uploadedLabels: action.payload,
+      uploadingLabels: false,
+    };
+  },
+  [setElementLabel.fulfilled]: (state, action) => {
+    const { element } = action.payload;
+    const label = element.user_labels[state.curCategory];
+    let newPosElemResult = [...state.posElemResult];
+    if (label === "true") {
+      if (!state.posElemResult.some((e) => e.id === element.id)) {
+        newPosElemResult = [...newPosElemResult, element];
+      }
+    } else {
+      newPosElemResult = newPosElemResult.filter((e) => e.id !== element.id);
+    }
+
+    const { initialLabelState: posElemLabelState } = parseElements(
+      newPosElemResult,
+      state.curCategory,
+      true
+    );
+
+    return {
+      ...state,
+      posElemResult: newPosElemResult,
+      posElemLabelState
+    };
+  },
+  [uploadLabels.rejected]: (state, action) => {
+    return {
+      ...state,
+      errorMessage: handleError(action.error),
+    };
+  },
+  [setElementLabel.rejected]: (state, action) => {
+    return {
+      ...state,
+      errorMessage: handleError(action.error),
+    };
+  },
+};

--- a/frontend/src/modules/Workplace/redux/searchSlice.js
+++ b/frontend/src/modules/Workplace/redux/searchSlice.js
@@ -1,0 +1,78 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { getCategoryQueryString, getQueryParamsString } from "../../../utils/utils";
+import { BASE_URL, WORKSPACE_API } from "../../../config"
+
+const getWorkspace_url = `${BASE_URL}/${WORKSPACE_API}`
+
+export const searchKeywords = createAsyncThunk(
+  "workspace/searchKeywords",
+  async (request, { getState }) => {
+    const state = getState();
+    const queryParams = getQueryParamsString([
+      `qry_string=${state.workspace.searchInput}`,
+      getCategoryQueryString(state.workspace.curCategory),
+      `sample_start_idx=0`,
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/query${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const reducers = {
+  resetSearchResults(state, _) {
+    state.searchResult = null;
+  },
+  setSearchLabelState(state, action) {
+    return {
+      ...state,
+      searchLabelState: action.payload,
+    };
+  },
+  setSearchInput(state, action) {
+    state.searchInput = action.payload;
+  },
+};
+
+export const extraReducers = {
+  [searchKeywords.fulfilled]: (state, action) => {
+    const data = action.payload;
+    let initialSearchLabelState = {};
+
+    for (let i = 0; i < data["elements"].length; i++) {
+      if (state.curCategory in data["elements"][i]["user_labels"]) {
+        if (data["elements"][i]["user_labels"][state.curCategory] == "true") {
+          initialSearchLabelState["L" + i + "-" + data["elements"][i].id] =
+            "pos";
+        } else if (
+          data["elements"][i]["user_labels"][state.curCategory] == "false"
+        ) {
+          initialSearchLabelState["L" + i + "-" + data["elements"][i].id] =
+            "neg";
+        } else {
+          initialSearchLabelState["L" + i + "-" + data["elements"][i].id] = "";
+        }
+      } else {
+        initialSearchLabelState["L" + i + "-" + data["elements"][i].id] = "";
+      }
+    }
+    return {
+      ...state,
+      searchResult: data.elements,
+      searchUniqueElemRes: data.hit_count_unique,
+      searchTotalElemRes: data.hit_count,
+      searchLabelState: initialSearchLabelState,
+    };
+  },
+};

--- a/frontend/src/modules/Workplace/redux/sidebarPanelsSlice.js
+++ b/frontend/src/modules/Workplace/redux/sidebarPanelsSlice.js
@@ -1,0 +1,367 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import {
+  getCategoryQueryString,
+  getQueryParamsString,
+  parseElements,
+} from "../../../utils/utils";
+import { BASE_URL, WORKSPACE_API, DOWNLOAD_LABELS_API, UPLOAD_LABELS_API } from "../../../config"
+
+const getWorkspace_url = `${BASE_URL}/${WORKSPACE_API}`;
+
+export const getElementToLabel = createAsyncThunk(
+  "workspace/getElementToLabel",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/active_learning${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const getPositiveElementForCategory = createAsyncThunk(
+  "workspace/getPositiveElementForCategory",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const curDocument =
+      state.workspace.documents[state.workspace.curDocId]["document_id"];
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    //var url = `${getWorkspace_url}/${state.workspace.workspace}/positive_elements?${getCategoryQueryString(state.workspace.curCategory)}`)
+
+    var url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/document/${encodeURIComponent(curDocument)}${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const getAllPositiveLabels = createAsyncThunk(
+  "workspace/getPositiveElements",
+  async (request, { getState }) => {
+    const state = getState();
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    const url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/positive_elements${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+    return data;
+  }
+);
+
+export const getDisagreementsElements = createAsyncThunk(
+  "workspace/getDisagreeElements",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    const url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/disagree_elements${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+    return data;
+  }
+);
+
+export const getSuspiciousLabels = createAsyncThunk(
+  "workspace/getSuspiciousElements",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    const url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/suspicious_elements${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+    return data;
+  }
+);
+
+export const getContradictingLabels = createAsyncThunk(
+  "workspace/getContradictiveElements",
+  async (request, { getState }) => {
+    const state = getState();
+
+    const queryParams = getQueryParamsString([
+      getCategoryQueryString(state.workspace.curCategory),
+    ]);
+
+    const url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/contradiction_elements${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+    return data;
+  }
+);
+
+export const getPositivePredictions = createAsyncThunk(
+  "workspace/getPositivePredictions",
+  async (request, { getState }) => {
+    const state = getState();
+    const queryParams = getQueryParamsString([
+      `size=100`,
+      getCategoryQueryString(state.workspace.curCategory),
+      `start_idx=0`,
+    ]);
+    const url = `${getWorkspace_url}/${encodeURIComponent(
+      state.workspace.workspaceId
+    )}/positive_predictions${queryParams}`;
+
+    const data = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.authenticate.token}`,
+      },
+      method: "GET",
+    }).then((response) => response.json());
+
+    return data;
+  }
+);
+
+export const reducers = {
+  setActivePanel(state, action) {
+    state.activePanel = action.payload
+  },
+  setSearchLabelState(state, action) {
+    state.searchLabelState = action.payload;
+  },
+  setRecommendToLabelState(state, action) {
+    state.recommendToLabelState = action.payload;
+  },
+  setPosPredLabelState(state, action) {
+    state.posPredLabelState = action.payload;
+  },
+  setPosElemLabelState(state, action) {
+    state.posElemLabelState = action.payload;
+  },
+  setDisagreeElemLabelState(state, action) {
+    state.disagreeElemLabelState = action.payload;
+  },
+  setSuspiciousElemLabelState(state, action) {
+    state.suspiciousElemLabelState = action.payload;
+  },
+  setContradictiveElemLabelState(state, action) {
+    state.contradictiveElemPairsLabelState = action.payload;
+  },
+};
+
+export const extraReducers = {
+  [getPositivePredictions.fulfilled]: (state, action) => {
+    const { elements, positive_fraction, hit_count } = action.payload;
+    const { initialLabelState } = parseElements(
+      elements,
+      state.curCategory,
+      true
+    );
+    return {
+      ...state,
+      posPredResult: elements,
+      posPredFraction: positive_fraction,
+      posPredTotalElemRes: hit_count,
+      posPredLabelState: initialLabelState,
+    };
+  },
+  [getAllPositiveLabels.fulfilled]: (state, action) => {
+    const { positive_elements } = action.payload;
+    const { initialLabelState } = parseElements(
+      positive_elements,
+      state.curCategory,
+      true
+    );
+
+    return {
+      ...state,
+      posElemResult: positive_elements,
+      posElemLabelState: initialLabelState,
+    };
+  },
+  [getDisagreementsElements.fulfilled]: (state, action) => {
+    const { disagree_elements } = action.payload;
+    const { initialLabelState } = parseElements(
+      disagree_elements,
+      state.curCategory,
+      true
+    );
+
+    return {
+      ...state,
+      disagreeElemResult: disagree_elements,
+      disagreeElemLabelState: initialLabelState,
+    };
+  },
+  [getSuspiciousLabels.fulfilled]: (state, action) => {
+    const { elements } = action.payload;
+    const { initialLabelState } = parseElements(
+      elements,
+      state.curCategory,
+      true
+    );
+
+    return {
+      ...state,
+      suspiciousElemResult: elements,
+      suspiciousElemLabelState: initialLabelState,
+    };
+  },
+  [getContradictingLabels.pending]: (state, action) => {
+    return {
+      ...state,
+      loadingContradictingLabels: true,
+    };
+  },
+  [getContradictingLabels.rejected]: (state, action) => {
+    return {
+      ...state,
+      loadingContradictingLabels: false,
+    };
+  },
+  [getContradictingLabels.fulfilled]: (state, action) => {
+    const data = action.payload;
+
+    const flattedPairs = data.pairs?.length ? data.pairs.flat() : [];
+
+    const { initialLabelState } = parseElements(
+      flattedPairs,
+      state.curCategory,
+      true
+    );
+
+    return {
+      ...state,
+      contradictiveElemDiffsResult: data.diffs,
+      contradictiveElemPairsResult: data.pairs,
+      contradictiveElemPairsLabelState: initialLabelState,
+      loadingContradictingLabels: false,
+    };
+  },
+  [getElementToLabel.fulfilled]: (state, action) => {
+    const data = action.payload;
+
+    let initRecommendToLabelState = {};
+
+    for (let i = 0; i < data["elements"].length; i++) {
+      if (state.curCategory in data["elements"][i]["user_labels"]) {
+        if (data["elements"][i]["user_labels"][state.curCategory] == "true") {
+          initRecommendToLabelState["L" + i + "-" + data["elements"][i].id] =
+            "pos";
+        } else if (
+          data["elements"][i]["user_labels"][state.curCategory] == "false"
+        ) {
+          initRecommendToLabelState["L" + i + "-" + data["elements"][i].id] =
+            "neg";
+        } else {
+          initRecommendToLabelState["L" + i + "-" + data["elements"][i].id] =
+            "";
+        }
+      } else {
+        initRecommendToLabelState["L" + i + "-" + data["elements"][i].id] = "";
+      }
+    }
+    return {
+      ...state,
+      elementsToLabel: data["elements"],
+      recommendToLabelState: initRecommendToLabelState,
+    };
+  },
+  [getPositiveElementForCategory.fulfilled]: (state, action) => {
+    const data = action.payload;
+
+    var elements = data["elements"];
+
+    // var doc_elements = [ ... state.elements ]
+
+    var predictionForDocCat = Array(state.elements.length - 1).fill(false);
+
+    elements.map((e, i) => {
+      // const docid = e['docid']
+      // var eids = e['id'].split('-')
+      // const eid = parseInt(eids[eids.length-1])
+
+      // if(docid == state.curDocName) {
+      //     // console.log(`eid: ${eid}, i: ${i}`)
+
+      //     predictionForDocCat[eid] = true
+      // }
+
+      if (state.curCategory in e["model_predictions"]) {
+        const pred = e["model_predictions"][state.curCategory];
+
+        if (pred == "true") {
+          predictionForDocCat[i] = true;
+        } else {
+          predictionForDocCat[i] = false;
+        }
+      }
+    });
+
+    return {
+      ...state,
+      predictionForDocCat: predictionForDocCat,
+    };
+  },
+};

--- a/frontend/src/modules/Workplace/sidebar/ContradictingLabelsPanel.jsx
+++ b/frontend/src/modules/Workplace/sidebar/ContradictingLabelsPanel.jsx
@@ -26,7 +26,7 @@ import { useSelector, useDispatch } from "react-redux";
 import Element from "./Element";
 import useSearchElement from "./customHooks/useSearchElement";
 import useLabelState from "./customHooks/useLabelState";
-import { getContradictingLabels } from "../DataSlice";
+import { getContradictingLabels } from "../redux/DataSlice";
 import contradictive_elem_icon from "../Asset/contradicting.svg";
 
 const ContradictingLabelsPanel = ({

--- a/frontend/src/modules/Workplace/sidebar/Element.jsx
+++ b/frontend/src/modules/Workplace/sidebar/Element.jsx
@@ -67,13 +67,13 @@ export default function Element(props) {
                 {workspace.curCategory !== null &&
                     <>
                         <div className={classes.resultbtn}
-                            onClick={(e) => { e.stopPropagation(); handlePosLabelState(docid, id, searchedIndex)}}>
+                            onClick={(e) => { e.stopPropagation(); handlePosLabelState(docid, id, searchedElemIndex)}}>
                             {labelState[searchedElemIndex] == 'pos' ?
                                 <img src={check} alt="checked" /> :
                                 <img className={classes.hovbtn} src={checking} alt="checking" />
                             }
                         </div>
-                        <div className={classes.resultbtn} positiveicon="false" onClick={(e) => {e.stopPropagation(); handleNegLabelState(docid, id, searchedIndex)}}>
+                        <div className={classes.resultbtn} positiveicon="false" onClick={(e) => {e.stopPropagation(); handleNegLabelState(docid, id, searchedElemIndex)}}>
                             {labelState[searchedElemIndex] == 'neg' ?
                                 <img src={cross} alt="crossed" /> :
                                 <img className={classes.hovbtn} src={crossing} alt="crossinging" />

--- a/frontend/src/modules/Workplace/sidebar/EvaluationPanel.jsx
+++ b/frontend/src/modules/Workplace/sidebar/EvaluationPanel.jsx
@@ -32,7 +32,7 @@ import {
   startEvaluation,
   getEvaluationResults,
   cancelEvaluation,
-} from "../DataSlice";
+} from "../redux/DataSlice";
 
 import {
   START_EVALUATION_MSG,

--- a/frontend/src/modules/Workplace/sidebar/PosPredictionsPanel.jsx
+++ b/frontend/src/modules/Workplace/sidebar/PosPredictionsPanel.jsx
@@ -20,7 +20,7 @@ import { useSelector } from "react-redux";
 import Element from "./Element";
 import useSearchElement from "./customHooks/useSearchElement";
 import useLabelState from "./customHooks/useLabelState";
-import { curCategoryNameSelector } from "../DataSlice";
+import { curCategoryNameSelector } from "../redux/DataSlice";
 
 const PosPredictionsPanel = ({ updateMainLabelState, updateLabelState }) => {
   const workspace = useSelector((state) => state.workspace);

--- a/frontend/src/modules/Workplace/sidebar/customHooks/useLabelState.js
+++ b/frontend/src/modules/Workplace/sidebar/customHooks/useLabelState.js
@@ -16,7 +16,7 @@
 import {
     setNumLabel,
     setNumLabelGlobal,
-} from '../../DataSlice';
+} from '../../redux/DataSlice';
 import { useSelector } from 'react-redux';
 
 

--- a/frontend/src/modules/Workplace/sidebar/customHooks/useLabelState.js
+++ b/frontend/src/modules/Workplace/sidebar/customHooks/useLabelState.js
@@ -55,7 +55,12 @@ const useLabelState = (
       labelAction
     );
 
-    dispatch(setElementLabel({ element_id: id, docid: docid, label: getBooleanLabel(newLabel)})).then(() => {
+    dispatch(setElementLabel({ 
+      element_id: id, 
+      docid: docid, 
+      label: getBooleanLabel(newLabel), 
+      update_counter: updateCounter
+    })).then(() => {
       dispatch(checkStatus())
 
       // if doc is L24-medium_wiki-Common house gecko-50 then elementMainIndex is L50

--- a/frontend/src/modules/Workplace/sidebar/customHooks/useSearchElement.js
+++ b/frontend/src/modules/Workplace/sidebar/customHooks/useSearchElement.js
@@ -14,7 +14,6 @@
 */
 
 import { useEffect } from 'react';
-import { searchKeywords } from '../../DataSlice.jsx';
 import {
     setFocusedState,
     fetchCertainDocument,
@@ -22,7 +21,8 @@ import {
     setSearchedIndex,
     setIsSearchActive,
     setSearchInput,
-} from '../../DataSlice';
+    searchKeywords
+} from '../../redux/DataSlice';
 import { useDispatch, useSelector } from 'react-redux';
 
 const useSearchElement = () => {

--- a/frontend/src/modules/Workplace/sidebar/customHooks/useTogglePanel.js
+++ b/frontend/src/modules/Workplace/sidebar/customHooks/useTogglePanel.js
@@ -15,10 +15,8 @@
 
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  sidebarOptionEnum
-} from "../../../../const";
-import {   setActivePanel } from '../../DataSlice';
+import { sidebarOptionEnum} from '../../../../const';
+import { setActivePanel } from '../../redux/DataSlice';
 
 const useTogglePanel = (setOpen, textInput) => {
 

--- a/frontend/src/modules/Workplace/sidebar/customHooks/useUpdateLabelState.js
+++ b/frontend/src/modules/Workplace/sidebar/customHooks/useUpdateLabelState.js
@@ -17,7 +17,6 @@ import { useDispatch } from 'react-redux';
 import {
     checkStatus,
     fetchElements,
-    increaseIdInBatch,
     setElementLabel,
     setRecommendToLabelState,
     setSearchLabelState,
@@ -41,9 +40,8 @@ const useUpdateLabelState = () => {
         dispatch(setSearchLabelState(newPanelLabelState))
     }
 
-    const updateMainLabelState = (id, docid, label, updateCounter) => {
-        dispatch(increaseIdInBatch())
-        dispatch(setElementLabel({ element_id: id, docid: docid, label: label, update_counter: updateCounter })).then(() => {
+    const updateMainLabelState = (id, docid, label) => {
+        dispatch(setElementLabel({ element_id: id, docid: docid, label: label })).then(() => {
             dispatch(checkStatus())
             dispatch(fetchElements())
         })

--- a/frontend/src/modules/Workplace/sidebar/customHooks/useUpdateLabelState.js
+++ b/frontend/src/modules/Workplace/sidebar/customHooks/useUpdateLabelState.js
@@ -27,7 +27,7 @@ import {
     setSuspiciousElemLabelState,
     setContradictiveElemLabelState,
     setEvaluationLabelState
-} from '../../DataSlice';
+} from '../../redux/DataSlice';
 
 
 /**

--- a/frontend/src/modules/Workplace/sidebar/customHooks/useUpdateLabelState.js
+++ b/frontend/src/modules/Workplace/sidebar/customHooks/useUpdateLabelState.js
@@ -56,7 +56,8 @@ const useUpdateLabelState = () => {
     }
 
     const updatePosElemLabelState = (newPanelLabelState) => {
-        dispatch(setPosElemLabelState(newPanelLabelState))
+        // elemLabelState update is manage in the setElementLabel.fulfilled action
+        return
     }   
 
     const updateDisagreelemLabelState = (newPanelLabelState) => {

--- a/frontend/src/modules/Workplace/upperbar/Modal/CreateCategoryModal.jsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/CreateCategoryModal.jsx
@@ -19,7 +19,7 @@ import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import Modal from '@mui/material/Modal';
 import { useDispatch, useSelector } from 'react-redux';
-import { createCategoryOnServer, fetchCategories } from '../../DataSlice';
+import { createCategoryOnServer, fetchCategories } from '../../redux/DataSlice';
 import TextField from '@mui/material/TextField';
 import classes from './index.module.css';
 import {

--- a/frontend/src/modules/Workplace/upperbar/Modal/DeleteCategoryModal.jsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/DeleteCategoryModal.jsx
@@ -23,7 +23,7 @@ import {
   DialogContentText,
 } from "@mui/material";
 import { useSelector, useDispatch } from "react-redux";
-import { curCategoryNameSelector, deleteCategory } from "../../DataSlice";
+import { curCategoryNameSelector, deleteCategory } from "../../redux/DataSlice";
 import { notify } from "../../../../utils/notification";
 
 export default function DeleteCategoryModal({ open, setOpen }) {

--- a/frontend/src/modules/Workplace/upperbar/Modal/EditCategoryModal.jsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/EditCategoryModal.jsx
@@ -20,14 +20,14 @@ import Typography from "@mui/material/Typography";
 import Modal from "@mui/material/Modal";
 import TextField from "@mui/material/TextField";
 import { useDispatch } from "react-redux";
-import { editCategory } from "../../DataSlice";
+import { editCategory } from "../../redux/DataSlice";
 import {
   CREATE_NEW_CATEGORY_PLACEHOLDER_MSG,
   WRONG_INPUT_NAME_LENGTH,
   REGEX_LETTER_NUMBERS_UNDERSCORE_SPACES,
   WRONG_INPUT_NAME_BAD_CHARACTER,
 } from "../../../../const";
-import { fetchCategories } from "../../DataSlice";
+import { fetchCategories } from "../../redux/DataSlice";
 import classes from "./index.module.css";
 import { notify } from "../../../../utils/notification";
 

--- a/frontend/src/modules/Workplace/upperbar/UpperBar.jsx
+++ b/frontend/src/modules/Workplace/upperbar/UpperBar.jsx
@@ -23,7 +23,7 @@ import ModeEditOutlineOutlinedIcon from '@mui/icons-material/ModeEditOutlineOutl
 import classes from './UpperBar.module.css';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
 import { useDispatch, useSelector } from 'react-redux';
-import { updateCurCategory } from '../DataSlice.jsx';
+import { updateCurCategory } from '../redux/DataSlice';
 import FormControl from '@mui/material/FormControl';
 import ControlledSelect from '../../../components/dropdown/Dropdown';
 import Tooltip from '@mui/material/Tooltip';

--- a/frontend/src/modules/Workplace/upperbar/UpperBar.jsx
+++ b/frontend/src/modules/Workplace/upperbar/UpperBar.jsx
@@ -99,7 +99,7 @@ function CategoryFormControl() {
   );
 }
 
-const UpperBar = ({ setNumLabel }) => {
+const UpperBar = () => {
   
   const curCategory = useSelector(state => state.workspace.curCategory)
   const [createCategoryModalOpen, setCreateCategoryModalOpen] = useState(false)

--- a/frontend/src/modules/Workplace/useErrorHandler.js
+++ b/frontend/src/modules/Workplace/useErrorHandler.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { toast } from "react-toastify";
-import { clearError } from "./DataSlice";
+import { clearError } from "./redux/DataSlice";
 
 export const useErrorHandler = () => {
   const toastRef = useRef(null);

--- a/frontend/src/modules/Workplace/useWorkspaceState.js
+++ b/frontend/src/modules/Workplace/useWorkspaceState.js
@@ -14,7 +14,7 @@
 */
 
 import {
-  getLabelNext,
+  getElementToLabel,
   checkStatus,
   fetchCategories,
   fetchDocuments,
@@ -22,7 +22,7 @@ import {
   setIsCategoryLoaded,
   checkModelUpdate,
   fetchElements,
-  getPosPredElementForCategory,
+  getPositiveElementForCategory,
   setFocusedState,
   getPositivePredictions,
   setWorkspaceVisited,
@@ -30,7 +30,7 @@ import {
   getSuspiciousLabels,
   getAllPositiveLabels,
   cleanEvaluationState,
-} from "./DataSlice.jsx";
+} from "./redux/DataSlice";
 import * as React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -88,8 +88,8 @@ const useWorkspaceState = () => {
       // checking for nullity first because in js null >= 0
       if (workspace.model_version !== null && workspace.model_version >= 0) {
         dispatch(fetchElements())
-        dispatch(getLabelNext());
-        dispatch(getPosPredElementForCategory());
+        dispatch(getElementToLabel());
+        dispatch(getPositiveElementForCategory());
         dispatch(getPositivePredictions())
         // dispatch(getDisagreementsElements())
         dispatch(getSuspiciousLabels())

--- a/frontend/src/modules/Workspace-config/index.jsx
+++ b/frontend/src/modules/Workspace-config/index.jsx
@@ -15,7 +15,7 @@
 
 import React, { useEffect } from 'react';
 import { clearState, getDatasets } from './workspaceConfigSlice'
-import { cleanWorkplaceState } from '../Workplace/DataSlice'
+import { cleanWorkplaceState } from '../Workplace/redux/DataSlice'
 import classes from "./workspace-config.module.css"
 import ExistingWorkspace from "./ExistingWorkspaceForm"
 import NewWorkspace from "./NewWorkspaceForm"

--- a/frontend/src/store/configureStore.js
+++ b/frontend/src/store/configureStore.js
@@ -16,7 +16,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { workspacesReducer } from '../modules/Workspace-config/workspaceConfigSlice'
 import { authenticateReducer } from '../modules/Login/LoginSlice'
-import workspaceReducer from '../modules/Workplace/DataSlice'
+import workspaceReducer from '../modules/Workplace/redux/DataSlice'
 
 const setupStore = preloadedState => configureStore({
   reducer: {

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -107,3 +107,43 @@ export const getNewLabelState = (currentLabel, action) => {
 export const getBooleanLabel = (label) => {
     return label === "pos" ? "true" : label === "neg" ? "false" : "none";
 }
+
+/**
+ * Parses the elements of a document extracting the user labels
+ * @param {list of elements of a document} elements
+ * @param {The current selected category} curCategory
+ * @param {whether to add the id of the element in its entry key} includeId
+ * @returns
+ */
+ export const parseElements = (elements, curCategory, includeId=false) => {
+  let initialFocusedState = {};
+  let initialLabelState = {};
+
+  let documentPos = 0;
+  let documentNeg = 0; 
+
+  for (const [i, element] of elements.entries()) {
+    let index = "L" + i
+    index = includeId ? `L${i}-${element.id}` : `L${i}`
+    initialFocusedState[index] = false;
+    const userLabels = element["user_labels"];
+    if (curCategory in userLabels) {
+      const label = userLabels[curCategory]
+      if (label === "true") {
+        initialLabelState[index] = "pos";
+        documentPos += 1;
+      } else if (label === "false") {
+        initialLabelState[index] = "neg";
+        documentNeg += 1;
+      }
+    } else {
+      initialLabelState[index] = "";
+    }
+  }
+  return {
+    initialFocusedState,
+    initialLabelState,
+    documentPos,
+    documentNeg,
+  };
+};

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -23,3 +23,17 @@ export const getOrdinalSuffix = (x) => {
     }
     return prefix
 }
+export const getCategoryQueryString = (curCategory) => {
+    return curCategory !== null ? `category_id=${curCategory}` : null
+}
+
+export const getQueryParamsString = (queryParams) => {
+    let queryParamsString = ''
+    queryParams.forEach(param => {
+        queryParamsString = param ? `${queryParamsString}${param}&` : queryParamsString
+    })
+    // add leading '?' removes last '&'
+    queryParamsString = '?' + queryParamsString.substring(0, queryParamsString.length-1)
+    // return an empty string if there are no query params
+    return queryParamsString === '?' ? '' : queryParamsString
+}

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -37,3 +37,73 @@ export const getQueryParamsString = (queryParams) => {
     // return an empty string if there are no query params
     return queryParamsString === '?' ? '' : queryParamsString
 }
+
+/**
+ * Implements the logic of deciding what's the resulting state of an element label based
+ * on its current label and the label action
+ * @param {The element's current label value. It can be '', 'neg' or 'pos'} currentLabel 
+ * @param {The label action. It can be: 'neg' or 'pos'} action 
+ * @returns 
+ */
+export const getNewLabelState = (currentLabel, action) => {
+    let documentLabelCountChange;
+    let newLabel;
+    if (currentLabel === 'pos') {
+      if (action === "pos") {
+        documentLabelCountChange = {
+          pos: -1,
+          neg: 0,
+        };
+        newLabel = "none";
+      } else if (action === "neg") {
+        documentLabelCountChange = {
+          pos: -1,
+          neg: 1,
+        };
+        newLabel = "neg";
+      }
+    } else if (currentLabel === "neg") {
+      if (action === "pos") {
+        documentLabelCountChange = {
+          pos: 1,
+          neg: -1,
+        };
+        newLabel = "pos";
+      } else if (action === "neg") {
+        documentLabelCountChange = {
+          pos: 0,
+          neg: -1,
+        };
+        newLabel = "none";
+      }
+    } else {
+      if (action === "pos") {
+        documentLabelCountChange = {
+          pos: 1,
+          neg: 0,
+        };
+        newLabel = "pos";
+      } else if (action === "neg") {
+        documentLabelCountChange = {
+          pos: 0,
+          neg: 1,
+        };
+        newLabel = "neg";
+      }
+    }
+    return {
+      documentLabelCountChange,
+      newLabel,
+    };
+  };
+
+/**
+ * Get's the boolean string of a label value, because currently we are using 
+ * 'pos' or 'neg' for internal labelling processes and 'true' or 'false' for
+ * the the REST API.
+ * @param {*} label 
+ * @returns 
+ */
+export const getBooleanLabel = (label) => {
+    return label === "pos" ? "true" : label === "neg" ? "false" : "none";
+}


### PR DESCRIPTION
This refactor includes to main changes:
- Redux state modularizing: divide the worksplace redux state into several slices. Each slice is composed by `reducers`  and `extraReducers`. The `extraReducers` are just reducers that are called by action thunks. We use action thunks to make API calls. The workplace slice has been devided into: category, labels, document, search, evaluation and sidebar slices. 
- Label mechanism improvement: this item includes code modularizing and improvements in readability and performance. However, this need further improvements. Currently, the labeling mechanism, which is in charge of synchronizing main and sidebar panels, uses two redux state objects. One for the elements, which has all the information that the backend returns, and one for the labeling status. When labeling happens only the latter is updated and thus the former gets outdated. In addition, the ids of the labeling status are a computation of the actual element id, thus synchronization requires more work. In a future refactor, I propose to merge this two objects into a single one. 