### PR TITLE
Enhancement: Erase unused tabStatus and setTabStatus

### DIFF
--- a/frontend/src/modules/Workplace/information/WorkspaceInfo.jsx
+++ b/frontend/src/modules/Workplace/information/WorkspaceInfo.jsx
@@ -138,7 +138,6 @@ export default function WorkspaceInfo({workspaceId, setTutorialOpen, checkModelI
     const nextModelShouldBeTraining = useSelector(state => state.workspace.nextModelShouldBeTraining)
 
     const [tabValue, setTabValue] = React.useState(0);
-    const [tabStatus, setTabStatus] = React.useState(0)
     const [uploadLabelsDialogOpen, setUploadLabelsDialogOpen] = React.useState(false)
     const [downloadLabelsDialogOpen, setDownloadLabelsDialogOpen] = React.useState(false)
     const refAnimationInstance = useRef(null);
@@ -246,7 +245,6 @@ export default function WorkspaceInfo({workspaceId, setTutorialOpen, checkModelI
 
     const handleChange = (event, newValue) => {
         setTabValue(newValue);
-        setTabStatus(newValue)
     };
 
     // placeholder for finding documents stats
@@ -359,9 +357,7 @@ export default function WorkspaceInfo({workspaceId, setTutorialOpen, checkModelI
                                     <Tab label="Document" {...a11yProps(1)} className={classes.tabs}/>
                                 </Tabs>
                             </Box>
-                            <TabPanel className={classes.entries_tab} value={tabValue} index={0} onClick={() => {
-                                setTabStatus('workspace')
-                            }}>
+                            <TabPanel className={classes.entries_tab} value={tabValue} index={0}>
                                 <Stack spacing={0}>
                                     <label style={{fontSize: '12px', opacity: 0.5}}>Labeled for entire workspace:</label>
                                     <StatsContainer>
@@ -378,9 +374,7 @@ export default function WorkspaceInfo({workspaceId, setTutorialOpen, checkModelI
                                     </StatsContainer>
                                 </Stack>
                             </TabPanel>
-                            <TabPanel className={classes.entries_tab} value={tabValue} index={1} onClick={() => {
-                                setTabStatus('document')
-                            }}>
+                            <TabPanel className={classes.entries_tab} value={tabValue} index={1}>
                                 <Stack spacing={0}>
                                     <label style={{fontSize: '12px', opacity: 0.5}}>Labeled for Current Doc:</label>
                                     <StatsContainer>


### PR DESCRIPTION
This PR aims to clean up the code mentioned in Issue https://github.com/label-sleuth/label-sleuth/issues/207.
Regarding code: Erased unused tabStatus and setTabStatus from WorkspaceInfo.jsx
    Developer's Certificate of Origin 1.1

    By making a contribution to this project, I certify that:

    (a) The contribution was created in whole or in part by me and I
        have the right to submit it under the open source license
        indicated in the file; or

    (b) The contribution is based upon previous work that, to the best
        of my knowledge, is covered under an appropriate open source
        license and I have the right under that license to submit that
        work with modifications, whether created in whole or in part
        by me, under the same open source license (unless I am
        permitted to submit under a different license), as indicated
        in the file; or

    (c) The contribution was provided directly to me by some other
        person who certified (a), (b) or (c) and I have not modified
        it.

    (d) I understand and agree that this project and the contribution
        are public and that a record of the contribution (including all
        personal information I submit with it, including my sign-off) is
        maintained indefinitely and may be redistributed consistent with
        this project or the open source license(s) involved.