### PR TITLE
make search not-regex by default

### DIFF
--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -525,7 +525,7 @@ def query(workspace_id):
 
     :param workspace_id:
     :request_arg category_id:
-    :request_arg qry_string: regular expression
+    :request_arg qry_string: query string
     :request_arg qry_size: number of elements to return
     :request_arg sample_start_idx: get elements starting from this index (for pagination)
     """

--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -535,18 +535,16 @@ def query(workspace_id):
     query_string = request.args.get('qry_string')
     sample_size = int(request.args.get('qry_size', 100))
     sample_start_idx = int(request.args.get('sample_start_idx', 0))
-
     dataset_name = curr_app.orchestrator_api.get_dataset_name(workspace_id)
     resp = curr_app.orchestrator_api.query(workspace_id, dataset_name, category_id=None,
                                            query=query_string, is_regex=False,
                                            unlabeled_only=False, sample_size=sample_size,
                                            sample_start_idx=sample_start_idx, remove_duplicates=True)
-
     sorted_elements = sorted(resp["results"], key=lambda te: get_natural_sort_key(te.uri))
     elements_transformed = elements_back_to_front(workspace_id, sorted_elements, category_id)
-
     res = {'elements': elements_transformed,
-           'hit_count': resp["hit_count"], 'hit_count_unique': resp["hit_count_unique"]}
+           'hit_count': resp["hit_count"],
+           'hit_count_unique': resp["hit_count_unique"]}
     return jsonify(res)
 
 

--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -537,7 +537,8 @@ def query(workspace_id):
     sample_start_idx = int(request.args.get('sample_start_idx', 0))
 
     dataset_name = curr_app.orchestrator_api.get_dataset_name(workspace_id)
-    resp = curr_app.orchestrator_api.query(workspace_id, dataset_name, category_id=None, query_regex=query_string,
+    resp = curr_app.orchestrator_api.query(workspace_id, dataset_name, category_id=None,
+                                           query=query_string, is_regex=False,
                                            unlabeled_only=False, sample_size=sample_size,
                                            sample_start_idx=sample_start_idx, remove_duplicates=True)
 

--- a/label_sleuth/data_access/data_access_api.py
+++ b/label_sleuth/data_access/data_access_api.py
@@ -125,8 +125,8 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_text_elements(self, workspace_id: str, dataset_name: str, sample_size: int = sys.maxsize,
-                          sample_start_idx: int = 0, query_regex: str = None, remove_duplicates=False,
-                          document_uri=None, random_state: int = 0) -> Mapping:
+                          sample_start_idx: int = 0, query: str = None, is_regex: bool = False,
+                          remove_duplicates=False, document_uri=None, random_state: int = 0) -> Mapping:
         """
         Sample *sample_size* TextElements from dataset_name, optionally limiting to those matching a query,
         and add their labels information for workspace_id, if available.
@@ -135,8 +135,9 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
         :param dataset_name: the name of the dataset from which TextElements are sampled
         :param sample_size: how many TextElements should be sampled
         :param sample_start_idx: get elements starting from this index (for pagination). Default is 0
-        :param query_regex: a regular expression that should be matched in the sampled TextElements. If None, then
-        no such filtering is performed.
+        :param query: a query string to search for in the sampled TextElements.
+                      If None, then no such filtering is performed.
+        :param is_regex: if True, the query string is interpreted as a regular expression (False by default)
         :param document_uri: get elements from a particular document
         :param remove_duplicates: if True, do not include elements that are duplicates of each other.
         :param random_state: provide an int seed to define a random state. Default is zero.
@@ -147,7 +148,8 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_unlabeled_text_elements(self, workspace_id: str, dataset_name: str, category_id: int,
-                                    sample_size: int = sys.maxsize, sample_start_idx: int = 0, query_regex: str = None,
+                                    sample_size: int = sys.maxsize, sample_start_idx: int = 0,
+                                    query: str = None, is_regex: bool = False,
                                     remove_duplicates=False, random_state: int = 0) -> Mapping:
         """
         Sample *sample_size* TextElements from dataset_name, unlabeled for category_id in workspace_id, optionally
@@ -158,8 +160,9 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
         :param category_id: we demand that the elements are not labeled for this category
         :param sample_size: how many TextElements should be sampled
         :param sample_start_idx: get elements starting from this index (for pagination). Default is 0
-        :param query_regex: a regular expression that should be matched in the sampled TextElements. If None, then
-        no such filtering is performed.
+        :param query: a query string to search for in the sampled TextElements.
+                      If None, then no such filtering is performed.
+        :param is_regex: if True, the query string is interpreted as a regular expression (False by default)
         :param remove_duplicates: if True, do not include elements that are duplicates of each other.
         :param random_state: provide an int seed to define a random state. Default is zero.
         :return: a dictionary with two keys: 'results' whose value is a list of TextElements, and 'hit_count' whose
@@ -169,7 +172,8 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_labeled_text_elements(self, workspace_id: str, dataset_name: str, category_id: int,
-                                  sample_size: int = sys.maxsize, query_regex: str = None,
+                                  sample_size: int = sys.maxsize,
+                                  query: str = None, is_regex: bool = False,
                                   remove_duplicates=False, random_state: int = 0) -> Mapping:
         """
         Sample *sample_size* TextElements from dataset_name, labeled for category_id in workspace_id,
@@ -179,8 +183,9 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
         :param dataset_name: the name of the dataset from which TextElements are sampled
         :param category_id: we demand that the elements are labeled for this category
         :param sample_size: how many TextElements should be sampled
-        :param query_regex: a regular expression that should be matched in the sampled TextElements. If None, then
-        no such filtering is performed.
+        :param query: a query string to search for in the sampled TextElements.
+                      If None, then no such filtering is performed.
+        :param is_regex: if True, the query string is interpreted as a regular expression (False by default)
         :param remove_duplicates: if True, do not include elements that are duplicates of each other.
         :param random_state: provide an int seed to define a random state. Default is zero.
         :return: a dictionary with two keys: 'results' whose value is a list of TextElements, and 'hit_count' whose

--- a/label_sleuth/data_access/file_based/file_based_data_access.py
+++ b/label_sleuth/data_access/file_based/file_based_data_access.py
@@ -225,7 +225,7 @@ class FileBasedDataAccess(DataAccessApi):
         return utils.build_text_elements_from_dataframe_and_labels(self._get_ds_in_memory(dataset_name), labels_dict={})
 
     def get_text_elements(self, workspace_id: str, dataset_name: str, sample_size: int = sys.maxsize,
-                          sample_start_idx: int = 0, query_regex: str = None, document_uri=None,
+                          sample_start_idx: int = 0, query: str = None, is_regex: bool = False, document_uri=None,
                           remove_duplicates=False, random_state: int = 0) -> Mapping:
         """
         Sample *sample_size* TextElements from dataset_name, optionally limiting to those matching a query,
@@ -235,8 +235,9 @@ class FileBasedDataAccess(DataAccessApi):
         :param dataset_name: the name of the dataset from which TextElements are sampled
         :param sample_size: how many TextElements should be sampled
         :param sample_start_idx: get elements starting from this index (for pagination). Default is 0
-        :param query_regex: a regular expression that should be matched in the sampled TextElements. If None, then
-        no such filtering is performed.
+        :param query: a query string to search for in the sampled TextElements.
+                      If None, then no such filtering is performed.
+        :param is_regex: if True, the query string is interpreted as a regular expression (False by default)
         :param document_uri: get elements from a particular document
         :param remove_duplicates: if True, do not include elements that are duplicates of each other.
         :param random_state: provide an int seed to define a random state. Default is zero.
@@ -248,14 +249,15 @@ class FileBasedDataAccess(DataAccessApi):
             results_dict = \
                 self._get_text_elements(
                     workspace_id=workspace_id, dataset_name=dataset_name,
-                    filter_func=lambda df, _: utils.filter_by_query_and_document_uri(df, query_regex, document_uri),
+                    filter_func=lambda df, _: utils.filter_by_query_and_document_uri(df, query, is_regex, document_uri),
                     sample_size=sample_size, sample_start_idx=sample_start_idx,
                     remove_duplicates=remove_duplicates, random_state=random_state)
 
         return results_dict
 
     def get_unlabeled_text_elements(self, workspace_id: str, dataset_name: str, category_id: int,
-                                    sample_size: int = sys.maxsize, sample_start_idx: int = 0, query_regex: str = None,
+                                    sample_size: int = sys.maxsize, sample_start_idx: int = 0,
+                                    query: str = None, is_regex: bool = False,
                                     remove_duplicates=False, random_state: int = 0) -> Mapping:
         """
         Sample *sample_size* TextElements from dataset_name, unlabeled for category_id in workspace_id, optionally
@@ -266,8 +268,9 @@ class FileBasedDataAccess(DataAccessApi):
         :param category_id: we demand that the elements are not labeled for this category
         :param sample_size: how many TextElements should be sampled
         :param sample_start_idx: get elements starting from this index (for pagination). Default is 0
-        :param query_regex: a regular expression that should be matched in the sampled TextElements. If None, then
-        no such filtering is performed.
+        :param query: a query string to search for in the sampled TextElements.
+                      If None, then no such filtering is performed.
+        :param is_regex: if True, the query string is interpreted as a regular expression (False by default)
         :param remove_duplicates: if True, do not include elements that are duplicates of each other.
         :param random_state: provide an int seed to define a random state. Default is zero.
         :return: a dictionary with two keys: 'results' whose value is a list of TextElements, and 'hit_count' whose
@@ -275,7 +278,7 @@ class FileBasedDataAccess(DataAccessApi):
         {'results': [TextElement], 'hit_count': int}
         """
         filter_func = lambda df, labels: \
-            utils.filter_by_query_and_label_status(df, labels, category_id, LabeledStatus.UNLABELED, query_regex)
+            utils.filter_by_query_and_label_status(df, labels, category_id, LabeledStatus.UNLABELED, query, is_regex)
 
         with self._get_lock_object_for_workspace(workspace_id):
             results_dict = self._get_text_elements(workspace_id=workspace_id, dataset_name=dataset_name,
@@ -285,7 +288,7 @@ class FileBasedDataAccess(DataAccessApi):
         return results_dict
 
     def get_labeled_text_elements(self, workspace_id: str, dataset_name: str, category_id: int,
-                                  sample_size: int = sys.maxsize, query_regex: str = None,
+                                  sample_size: int = sys.maxsize, query: str = None, is_regex: bool = False,
                                   remove_duplicates=False, random_state: int = 0) -> Mapping:
         """
         Sample *sample_size* TextElements from dataset_name, labeled for category_id in workspace_id,
@@ -295,8 +298,9 @@ class FileBasedDataAccess(DataAccessApi):
         :param dataset_name: the name of the dataset from which TextElements are sampled
         :param category_id: we demand that the elements are labeled for this category
         :param sample_size: how many TextElements should be sampled
-        :param query_regex: a regular expression that should be matched in the sampled TextElements. If None, then
-        no such filtering is performed.
+        :param query: a query string to search for in the sampled TextElements.
+                      If None, then no such filtering is performed.
+        :param is_regex: if True, the query string is interpreted as a regular expression (False by default)
         :param remove_duplicates: if True, do not include elements that are duplicates of each other.
         :param random_state: provide an int seed to define a random state. Default is zero.
         :return: a dictionary with two keys: 'results' whose value is a list of TextElements, and 'hit_count' whose
@@ -304,7 +308,7 @@ class FileBasedDataAccess(DataAccessApi):
         {'results': [TextElement], 'hit_count': int}
         """
         filter_func = lambda df, labels: \
-            utils.filter_by_query_and_label_status(df, labels, category_id, LabeledStatus.LABELED, query_regex)
+            utils.filter_by_query_and_label_status(df, labels, category_id, LabeledStatus.LABELED, query, is_regex)
 
         with self._get_lock_object_for_workspace(workspace_id):
             results_dict = self._get_text_elements(workspace_id=workspace_id, dataset_name=dataset_name,

--- a/label_sleuth/data_access/file_based/file_based_data_access.py
+++ b/label_sleuth/data_access/file_based/file_based_data_access.py
@@ -309,7 +309,6 @@ class FileBasedDataAccess(DataAccessApi):
         """
         filter_func = lambda df, labels: \
             utils.filter_by_query_and_label_status(df, labels, category_id, LabeledStatus.LABELED, query, is_regex)
-
         with self._get_lock_object_for_workspace(workspace_id):
             results_dict = self._get_text_elements(workspace_id=workspace_id, dataset_name=dataset_name,
                                                    filter_func=filter_func, sample_size=sample_size,

--- a/label_sleuth/data_access/file_based/utils.py
+++ b/label_sleuth/data_access/file_based/utils.py
@@ -61,10 +61,8 @@ def filter_by_labeled_status(df: pd.DataFrame, labels: pd.Series, category_id: i
     """
     if labeled_status == LabeledStatus.UNLABELED:
         return df[labels.apply(lambda x: category_id not in x)]
-
     elif labeled_status == LabeledStatus.LABELED:
         return df[labels.apply(lambda x: category_id in x)]
-
     return df
 
 

--- a/label_sleuth/data_access/file_based/utils.py
+++ b/label_sleuth/data_access/file_based/utils.py
@@ -68,11 +68,11 @@ def filter_by_labeled_status(df: pd.DataFrame, labels: pd.Series, category_id: i
     return df
 
 
-def filter_by_query_and_document_uri(df: pd.DataFrame, query, document_id=None):
+def filter_by_query_and_document_uri(df: pd.DataFrame, query, document_id=None, regex=False):
     if document_id is not None:
         df = df[df.uri.str.startswith(f"{document_id}-")]
     if query:
-        return df[df.text.str.contains(query, flags=re.IGNORECASE, na=False)]
+        df = df[df.text.str.contains(query, flags=re.IGNORECASE, na=False, regex=regex)]
     return df
 
 

--- a/label_sleuth/data_access/file_based/utils.py
+++ b/label_sleuth/data_access/file_based/utils.py
@@ -68,16 +68,15 @@ def filter_by_labeled_status(df: pd.DataFrame, labels: pd.Series, category_id: i
     return df
 
 
-def filter_by_query_and_document_uri(df: pd.DataFrame, query, document_id=None, regex=False):
+def filter_by_query_and_document_uri(df: pd.DataFrame, query, is_regex: bool = False, document_id=None):
     if document_id is not None:
         df = df[df.uri.str.startswith(f"{document_id}-")]
     if query:
-        df = df[df.text.str.contains(query, flags=re.IGNORECASE, na=False, regex=regex)]
+        df = df[df.text.str.contains(query, flags=re.IGNORECASE, na=False, regex=is_regex)]
     return df
 
 
 def filter_by_query_and_label_status(df: pd.DataFrame, labels_series: pd.Series, category_id: int,
-                                     labeled_status: LabeledStatus, query: str):
+                                     labeled_status: LabeledStatus, query: str, is_regex: bool = False):
     df = filter_by_labeled_status(df, labels_series, category_id, labeled_status)
-    df = filter_by_query_and_document_uri(df, query)
-    return df
+    return filter_by_query_and_document_uri(df, query, is_regex)

--- a/label_sleuth/data_access/label_import_utils.py
+++ b/label_sleuth/data_access/label_import_utils.py
@@ -36,10 +36,9 @@ def get_element_group_by_texts(texts: Sequence[str], workspace_id, dataset_name,
     remove_duplicates = False if doc_uri is not None else True
     regex = '|'.join(f'^{re.escape(t)}$' for t in texts)
     elements = data_access.get_text_elements(workspace_id=workspace_id, dataset_name=dataset_name,
-                                             sample_size=sys.maxsize, query_regex=regex, document_uri=doc_uri,
-                                             remove_duplicates=remove_duplicates)['results']
-
-    return elements
+                                             sample_size=sys.maxsize, query=regex, is_regex=True,
+                                             document_uri=doc_uri, remove_duplicates=remove_duplicates)
+    return elements['results']
 
 
 def process_labels_dataframe(workspace_id, dataset_name, data_access, labels_df_to_import: pd.DataFrame) \

--- a/label_sleuth/orchestrator/orchestrator_api.py
+++ b/label_sleuth/orchestrator/orchestrator_api.py
@@ -748,8 +748,8 @@ class OrchestratorApi:
             elements = self.get_all_unlabeled_text_elements(workspace_id, dataset_name, category_id,
                                                             remove_duplicates=remove_duplicates)
         else:
-            elements = self.data_access.get_text_elements(
-                workspace_id=workspace_id, dataset_name=dataset_name, remove_duplicates=remove_duplicates)["results"]
+            elements = self.data_access.get_text_elements(workspace_id=workspace_id, dataset_name=dataset_name,
+                                                          remove_duplicates=remove_duplicates)["results"]
         predictions = self.infer(workspace_id, category_id, elements)
         elements_with_matching_prediction = [text_element for text_element, prediction in zip(elements, predictions)
                                              if prediction.label == required_label]

--- a/label_sleuth/orchestrator/orchestrator_api.py
+++ b/label_sleuth/orchestrator/orchestrator_api.py
@@ -218,7 +218,8 @@ class OrchestratorApi:
                                                             sample_size=sys.maxsize,
                                                             remove_duplicates=remove_duplicates)['results']
 
-    def query(self, workspace_id: str, dataset_name: str, category_id: Union[int, None], query_regex: str,
+    def query(self, workspace_id: str, dataset_name: str, category_id: Union[int, None],
+              query: str, is_regex: bool = False,
               sample_size: int = sys.maxsize, sample_start_idx: int = 0, unlabeled_only: bool = False,
               remove_duplicates=False) -> Mapping[str, object]:
         """
@@ -227,7 +228,8 @@ class OrchestratorApi:
         :param workspace_id:
         :param dataset_name:
         :param category_id: optional. If unlabeled_only is True category_id will be used for determining unlabeled
-        :param query_regex: string
+        :param query: string
+        :param is_regex: if True, the query string is interpreted as a regular expression (False by default)
         :param unlabeled_only: if True, filters out labeled elements
         :param sample_size: maximum items to return
         :param sample_start_idx: get elements starting from this index (for pagination)
@@ -247,7 +249,7 @@ class OrchestratorApi:
         else:
             return self.data_access.get_text_elements(workspace_id=workspace_id, dataset_name=dataset_name,
                                                       sample_size=sample_size, sample_start_idx=sample_start_idx,
-                                                      query_regex=query_regex, remove_duplicates=remove_duplicates)
+                                                      query=query, is_regex=is_regex, remove_duplicates=remove_duplicates)
 
     def set_labels(self, workspace_id: str, uri_to_label: Mapping[str, Mapping[int, Label]],
                    apply_to_duplicate_texts=True, update_label_counter=True):


### PR DESCRIPTION
for #219

interpret the `qry_string` parameter as just a string (not regex by default.

add an extra parameter `is_regex` to `orchestrator_api.query()`.
(this param is False for query(), but True in the context of `label_import_utils.get_element_group_by_texts()`)

DCO 1.1:
```
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```