### PR TITLE
fix: reduce model path length

### DIFF
--- a/label_sleuth/models/core/model_api.py
+++ b/label_sleuth/models/core/model_api.py
@@ -272,10 +272,10 @@ class ModelAPI(object, metaclass=abc.ABCMeta):
         os.remove(self.get_in_progress_flag_path(model_id))
 
     def get_completed_flag_path(self, model_id):
-        return os.path.join(self.get_model_dir_by_id(model_id), f'train_complete_for_{model_id}')
+        return os.path.join(self.get_model_dir_by_id(model_id), f'train_complete')
 
     def get_in_progress_flag_path(self, model_id):
-        return os.path.join(self.get_model_dir_by_id(model_id), f'train_in_progress_for_{model_id}')
+        return os.path.join(self.get_model_dir_by_id(model_id), f'train_in_progress')
 
     def save_metadata(self, model_id, language: Language, model_params: Mapping):
         """


### PR DESCRIPTION
for #237 
Windows has a limit of 260 characters for paths. Since the ensemble model name is a concatenation of 2 model ids, we sometimes exceed this limit. To avoid this, model_id was removed from the train_in_progress and train_complete file markers. Since these 2 files are in the model directory, using the id for them is redundant.