### PR TITLE
feat: export according to the TrainingSetSelectionStrategy

### DIFF
--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -691,8 +691,13 @@ def export_labels(workspace_id):
     for a specific category. Column names for the various fields are listed under DisplayFields.
 
     :param workspace_id:
+    :request_arg labeled_only: only export elements as they were labeled by the user. If set to False, use the
+    TrainingSetSelectionStrategy to determine the exported elements
     """
-    return curr_app.orchestrator_api.export_workspace_labels(workspace_id).to_csv(index=False)
+    labeled_only = request.args.get('labeled_only', "true")
+    labeled_only = labeled_only.lower() == "true"
+
+    return curr_app.orchestrator_api.export_workspace_labels(workspace_id, labeled_only).to_csv(index=False)
 
 
 """

--- a/label_sleuth/data_access/data_access_api.py
+++ b/label_sleuth/data_access/data_access_api.py
@@ -190,7 +190,7 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_label_counts(self, workspace_id: str, dataset_name: str, category_id: int, remove_duplicates=False) \
-            -> Mapping[str, int]:
+            -> Mapping[bool, int]:
         """
         Return for each label value, assigned to category_id, the total count of its appearances in dataset_name.
         :param workspace_id: the workspace_id of the labeling effort.

--- a/label_sleuth/orchestrator/test_orchestrator_api.py
+++ b/label_sleuth/orchestrator/test_orchestrator_api.py
@@ -145,7 +145,7 @@ class TestOrchestratorAPI(unittest.TestCase):
 
         # use export_workspace_labels() to turn labeled_elements_for_export into a dataframe for export
         with patch.object(FileBasedDataAccess, 'get_labeled_text_elements', side_effect=mock_get_labeled_text_elements):
-            exported_df = self.orchestrator_api.export_workspace_labels('mock_workspace_1')
+            exported_df = self.orchestrator_api.export_workspace_labels('mock_workspace_1', True)
 
         for column in exported_df.columns:
             self.assertIn(column, DisplayFields.__dict__.values())


### PR DESCRIPTION
for #174 

This change adds a flag for the export_labels endpoint to export elements according to the elements that the system uses for training a model. For example, if the TrainingSetSelectionStrategy adds weakly labeled elements, these weakly labeled elements will also be exported.