### PR TITLE
Add new model iteration

### DIFF
--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -21,7 +21,7 @@ interface CheckStatusResponse {
   labeling_counts: { true: number; false: number };
 }
 
-interface UnparsedModel {
+interface UnparsedIteration {
   changed_fraction?: number;
   creation_epoch: number;
   iteration: number;

--- a/frontend/src/modules/Workplace/redux/modelSlice.ts
+++ b/frontend/src/modules/Workplace/redux/modelSlice.ts
@@ -110,8 +110,8 @@ export const extraReducers = [
           if (iteration["iteration_status"] === "READY") {
             latestReadyModelVersion = iteration["iteration"];
           } else if (
-            ["TRAINING", "RUNNING_INFERENCE", "RUNNING_ACTIVE_LEARNING", "CALCULATING_STATISTICS"].includes(
-              m["iteration_status"]
+            ["PREPARING_DATA", "TRAINING", "RUNNING_INFERENCE", "RUNNING_ACTIVE_LEARNING", "CALCULATING_STATISTICS"].includes(
+              iteration["iteration_status"]
             )
           ) {
             modelIsTraining = true;

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -21,9 +21,9 @@ import { modelUpdateExample, workspacesExample, datasetsExample, categoriesExamp
 jest.setTimeout(10000);
 
 const handlers = [
-  rest.get("/workspace/:workspace_id/models", (req, res, ctx) => {
-    const models = modelUpdateExample;
-    return res(ctx.delay(), ctx.json(models));
+  rest.get("/workspace/:workspace_id/iterations", (req, res, ctx) => {
+    const iterations = modelUpdateExample;
+    return res(ctx.delay(), ctx.json(iterations));
   }),
   rest.get(`/workspaces`, (req, res, ctx) => {
     return res(ctx.delay(), ctx.json(workspacesExample));

--- a/frontend/src/utils/test-utils.js
+++ b/frontend/src/utils/test-utils.js
@@ -59,7 +59,7 @@ export const createCategory = async () => {
 
 
 export const modelUpdateExample = {
-  models: [
+  iterations: [
     {
       iteration_status: "READY",
       iteration: 4,

--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -784,12 +784,12 @@ def get_labelling_status(workspace_id):
     })
 
 
-@main_blueprint.route("/workspace/<workspace_id>/models", methods=['GET'])
+@main_blueprint.route("/workspace/<workspace_id>/iterations", methods=['GET'])
 @login_if_required
 @validate_category_id
 @validate_workspace_id
 @cross_origin()
-def get_all_models_for_category(workspace_id):
+def get_all_iterations_for_category(workspace_id):
     """
     Return information about all the Iteration flows for this category and their current status.
 
@@ -799,7 +799,7 @@ def get_all_models_for_category(workspace_id):
     """
     category_id = int(request.args['category_id'])
     iterations = curr_app.orchestrator_api.get_all_iterations_for_category(workspace_id, category_id)
-    res = {'models': extract_iteration_information_list(iterations)}
+    res = {'iterations': extract_iteration_information_list(iterations)}
     return jsonify(res)
 
 

--- a/label_sleuth/test_app.py
+++ b/label_sleuth/test_app.py
@@ -164,8 +164,8 @@ class TestAppIntegration(unittest.TestCase):
 
         res = self.wait_for_new_iteration(category_id, res, workspace_name, 1)
 
-        self.assertEqual(200, res.status_code, msg="Failed to get models list")
-        self.assertEqual(1, len(res.get_json()["models"]), msg="first model was not added to the models list")
+        self.assertEqual(200, res.status_code, msg="Failed to get iterations list")
+        self.assertEqual(1, len(res.get_json()["iterations"]), msg="first model was not added to the models list")
 
         # get active learning recommendations
         res = self.client.get(f"/workspace/{workspace_name}/active_learning?category_id={category_id}",
@@ -287,7 +287,7 @@ class TestAppIntegration(unittest.TestCase):
         # wait for the second models
         res = self.wait_for_new_iteration(category_id, res, workspace_name, 2)
         self.assertEqual(200, res.status_code, msg="Failed to get models list")
-        self.assertEqual(2, len(res.get_json()["models"]), msg="second model was not added to the models list")
+        self.assertEqual(2, len(res.get_json()["iterations"]), msg="second model was not added to the models list")
 
         # update existing category
         new_category_name = f'{category_name}_new'
@@ -328,12 +328,12 @@ class TestAppIntegration(unittest.TestCase):
         while waiting_count < MAX_WAITING_FOR_TRAINING:
             # since get_status is asynchronously starting a new training, we need to wait until it added to the
             # iterations list and finishes successfully
-            res = self.client.get(f"/workspace/{workspace_name}/models?category_id={category_id}",
+            res = self.client.get(f"/workspace/{workspace_name}/iterations?category_id={category_id}",
                                   headers=HEADERS)
             response = res.get_json()
             print(response)
-            if res.status_code != 200 or (len(response["models"]) == num_models
-                                          and response['models'][0]['iteration_status'] == IterationStatus.READY.name):
+            if res.status_code != 200 or (len(response["iterations"]) == num_models
+                                          and response['iterations'][0]['iteration_status'] == IterationStatus.READY.name):
                 break
             time.sleep(0.1)
             waiting_count += 1


### PR DESCRIPTION
This PR changes the wording of the information about the iterations of the current category from `model` to `iteration`. This PR also adds the new iteration status `PREPARING_DATA` to the list of training statuses that the frontend recognizes. 