### PR TITLE
Add the 'delete dataset' functionality

### DIFF
--- a/frontend/src/components/combobox/ComboBoxWithInputText.jsx
+++ b/frontend/src/components/combobox/ComboBoxWithInputText.jsx
@@ -23,7 +23,6 @@ const ComboBoxWithInputText = forwardRef(({ options, handleInputChange, label, p
     <Stack spacing={3} sx={{ width: '100%' }} >
       <Autocomplete
         onInputChange={handleInputChange}
-        id="free-solo-demo"
         freeSolo
         options={options && options.map((option) => option.dataset_id)}
         renderInput={(params) =>

--- a/frontend/src/customHooks/useNotifyUploadedLabels.ts
+++ b/frontend/src/customHooks/useNotifyUploadedLabels.ts
@@ -4,6 +4,7 @@ import { useNotification } from "../utils/notification";
 import { UPLOAD_LABELS_WAIT_MESSAGE } from "../const";
 import { toast } from "react-toastify";
 import { usePrevious } from "./usePrevious";
+import { stringifyList } from "../utils/utils";
 
 export const useNotifyUploadedLabels = () => {
   const uploadedLabels = useAppSelector((state) => state.workspace.uploadedLabels);
@@ -11,13 +12,7 @@ export const useNotifyUploadedLabels = () => {
   const { notify, updateNotification, closeNotification } = useNotification();
 
   const getCategoriesString = useCallback((categories: string[]) => {
-    if (categories.length === 1) return categories[0];
-    else {
-      let res = "";
-      if (categories.length > 2) categories.slice(0, -2).forEach((c) => (res += `'${c}', `));
-      res += `'${categories.slice(-2, -1)[0]}' and '${categories.slice(-1)[0]}'`;
-      return res;
-    }
+    
   }, []);
 
   const previousUploadingLabels = usePrevious(uploadingLabels);
@@ -29,7 +24,7 @@ export const useNotifyUploadedLabels = () => {
     } else if (uploadedLabels !== null) {
       const categoriesCreated = uploadedLabels.categoriesCreated;
       const createdCategoriesMessage = categoriesCreated.length
-        ? `Added categories are: ${getCategoriesString(categoriesCreated)}`
+        ? `Added categories are: ${stringifyList(categoriesCreated)}`
         : "";
       updateNotification({
         toastId,

--- a/frontend/src/modules/Workspace-config/DeleteDatasetModal.tsx
+++ b/frontend/src/modules/Workspace-config/DeleteDatasetModal.tsx
@@ -1,0 +1,136 @@
+/*
+    Copyright (c) 2022 IBM Corp.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import * as React from "react";
+import Button from "@mui/material/Button";
+import { Box, Checkbox, Dialog, List, ListItem, Stack, Typography } from "@mui/material";
+import { DialogTitle, DialogActions, DialogContent, DialogContentText } from "@mui/material";
+import { useAppDispatch } from "../../customHooks/useRedux";
+import { getWorkspacesByDatasetName } from "./workspaceConfigSlice";
+import { isFulfilled } from "@reduxjs/toolkit";
+import ErrorIcon from "@mui/icons-material/Error";
+
+interface DeleteDatasetModalProps {
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  handleDeleteDataset: () => void;
+  value: string;
+  clearFields: () => void;
+}
+
+export const DeleteDatasetModal = ({
+  open,
+  setOpen,
+  handleDeleteDataset,
+  value,
+  clearFields,
+}: DeleteDatasetModalProps) => {
+  const dispatch = useAppDispatch();
+
+  const [workspacesUsingDataset, setWorkspacesUsingDataset] = React.useState<string[] | null>(null);
+  const [checkboxChecked, setCheckboxChecked] = React.useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCheckboxChecked(event.target.checked);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const onSubmit = () => {
+    setOpen(false);
+    handleDeleteDataset();
+    clearFields();
+  };
+
+
+  React.useEffect(() => {
+    if (!open) {
+    }
+  }, [open])
+
+  React.useEffect(() => {
+    if (open) {
+      // resets the workspaces using the dataset when the modal gets closed
+      // this preven the YES button from being enabled in case getting the workspaces fails
+      // and thus the user can't click YES
+      dispatch(getWorkspacesByDatasetName(value)).then((action: any) => {
+        if (isFulfilled(action)) {
+          setWorkspacesUsingDataset(action.payload["used_by"] as string[]);
+        }
+      });
+    }
+  }, [dispatch, value, open]);
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>{`Are you sure you want to delete the dataset '${value}'?`}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          This action will permanently delete the dataset. The deletion cannot be reversed.
+        </DialogContentText>
+        {workspacesUsingDataset !== null && workspacesUsingDataset.length > 0 ? (
+          <Box sx={{ marginTop: 4 }}>
+            <Stack direction="row">
+              <ErrorIcon
+                sx={(theme) => ({
+                  color: theme.palette.error.main,
+                  pr: 1,
+                  pl: 1,
+                })}
+              />
+              <DialogContentText>The following workspaces use this dataset and will be deleted too:</DialogContentText>
+            </Stack>
+            <List
+              sx={{
+                listStyleType: "circle",
+                "& .MuiListItem-root": {
+                  display: "list-item",
+                },
+                pl: 6,
+                pb: 2,
+              }}
+            >
+              {workspacesUsingDataset !== null &&
+                workspacesUsingDataset.map((workspace, i) => (
+                  <ListItem sx={{ pb: 0, pt: 0 }}>
+                    <DialogContentText>{workspace}</DialogContentText>
+                  </ListItem>
+                ))}
+            </List>
+            <Stack direction="row" sx={{ alignItems: "center" }}>
+              <Checkbox checked={checkboxChecked} onChange={handleChange} inputProps={{ "aria-label": "controlled" }} />
+              <DialogContentText>
+                I understand that the listed workspaces are going to be deleted along with all the categories, labels,
+                and models associated with them.
+              </DialogContentText>
+            </Stack>
+          </Box>
+        ) : null}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>No</Button>
+        <Button
+          onClick={onSubmit}
+          autoFocus
+          disabled={workspacesUsingDataset === null || (workspacesUsingDataset.length > 0 && !checkboxChecked)}
+        >
+          Yes
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/modules/Workspace-config/DeleteWorkspaceModal.tsx
+++ b/frontend/src/modules/Workspace-config/DeleteWorkspaceModal.tsx
@@ -18,7 +18,14 @@ import Button from "@mui/material/Button";
 import { Dialog } from "@mui/material";
 import { DialogTitle, DialogActions, DialogContent, DialogContentText } from "@mui/material";
 
-export default function DeleteCategoryModal({ open, setOpen, handleDeleteWorkspace, value }) {
+interface DeleteWorkspaceModalProps {
+  open: boolean, 
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>, 
+  handleDeleteWorkspace: () => void, 
+  value: string,
+}
+
+export const DeleteWorkspaceModal = ({ open, setOpen, handleDeleteWorkspace, value }: DeleteWorkspaceModalProps) => {
   const handleClose = () => {
     setOpen(false);
   };
@@ -29,7 +36,6 @@ export default function DeleteCategoryModal({ open, setOpen, handleDeleteWorkspa
   };
 
   return (
-    <div>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>{`Are you sure you want to delete the workspace '${value}'?`}</DialogTitle>
         <DialogContent>
@@ -45,6 +51,5 @@ export default function DeleteCategoryModal({ open, setOpen, handleDeleteWorkspa
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
   );
 }

--- a/frontend/src/modules/Workspace-config/ExistingWorkspaceForm.jsx
+++ b/frontend/src/modules/Workspace-config/ExistingWorkspaceForm.jsx
@@ -20,7 +20,7 @@ import Box from "@mui/material/Box";
 import ButtonIBM from "../../components/buttons/ButtonIBM";
 import buttonIBMClasses from "../../components/buttons/Buttons.module.css";
 import classes from "./workspace-config.module.css";
-import DeleteCategoryModal from "./DeleteWorkspaceModal";
+import { DeleteWorkspaceModal } from "./DeleteWorkspaceModal";
 
 const ExistingWorkspaceForm = ({
   handleChange,
@@ -34,7 +34,7 @@ const ExistingWorkspaceForm = ({
 
   return (
     <Box className={classes.wrapper} style={{ borderBottom: "solid 1px #8d8d8d" }}>
-      <DeleteCategoryModal
+      <DeleteWorkspaceModal
         open={deleteWorkspaceModalOpen}
         setOpen={setDeleteWorkspaceModalOpen}
         handleDeleteWorkspace={handleDeleteWorkspace}

--- a/frontend/src/modules/Workspace-config/LoadDocumentForm.jsx
+++ b/frontend/src/modules/Workspace-config/LoadDocumentForm.jsx
@@ -13,85 +13,121 @@
     limitations under the License.
 */
 
-import classes from "./workspace-config.module.css"
-import FormControl from '@mui/material/FormControl';
-import FormLabel from '@mui/material/FormLabel';
-import Box from '@mui/material/Box';
-import ButtonIBM from "../../components/buttons/ButtonIBM"
-import buttonIBMClasses from "../../components/buttons/Buttons.module.css"
-import TextField from '@mui/material/TextField';
+import React from "react";
+import classes from "./workspace-config.module.css";
+import FormControl from "@mui/material/FormControl";
+import FormLabel from "@mui/material/FormLabel";
+import Box from "@mui/material/Box";
+import ButtonIBM from "../../components/buttons/ButtonIBM";
+import buttonIBMClasses from "../../components/buttons/Buttons.module.css";
+import TextField from "@mui/material/TextField";
 import ComboBoxWithInputText from "../../components/combobox/ComboBoxWithInputText";
-import data_icon from "../../assets/workspace-config/document--add.svg"
-import { UPLOAD_NEW_DATASET_MSG, UPLOAD_NEW_DATASET_NAME_PLACEHOLER_MSG, UPLOAD_NEW_DATASET_FILE_HELPER_MSG } from '../../const';
-import Backdrop from '@mui/material/Backdrop';
-import CircularProgress from '@mui/material/CircularProgress';
+import data_icon from "../../assets/workspace-config/document--add.svg";
+import {
+  UPLOAD_NEW_DATASET_MSG,
+  UPLOAD_NEW_DATASET_NAME_PLACEHOLER_MSG,
+  UPLOAD_NEW_DATASET_FILE_HELPER_MSG,
+} from "../../const";
+import Backdrop from "@mui/material/Backdrop";
+import CircularProgress from "@mui/material/CircularProgress";
+import { DeleteDatasetModal } from "./DeleteDatasetModal";
 
-const LoadDocumentForm = ({ handleLoadDoc, handleFileChange, datasets, handleInputChange, textFieldRef, comboInputTextRef, backdropOpen, datasetNameError }) => {
+const LoadDocumentForm = ({
+  handleLoadDoc,
+  handleFileChange,
+  datasets,
+  handleInputChange,
+  textFieldRef,
+  comboInputTextRef,
+  backdropOpen,
+  datasetNameError,
+  deleteButtonEnabled,
+  datasetName,
+  handleDeleteDataset,
+  clearFields,
+}) => {
+  const [deleteDatasetModalOpen, setDeleteDatasetModalOpen] = React.useState(false);
 
-    return (
-        <Box className={classes.wrapper} style={{ borderRight: 'none' }}>
-            <div className={classes.sleuth_header}>
-                <img alt="dataset" src={data_icon} style={{ width: '16px', height: '16px', marginRight: '6px' }} />
-                <h4 style={{ fontSize: '16px', fontWeight: '400', margin: 0, paddingTop: '2px' }}>New Documents</h4>
-            </div>
-            <div style={{ borderRight: 'solid 1px #8d8d8d' }}>
-                <h2 style={{ padding: '25px', margin: 0 }}>Upload</h2>
-                <FormControl variant="standard" sx={{ m: 0, width: '350px' }}>
-                    <FormLabel style={{
-                        paddingLeft: '25px',
-                        paddingRight: '25px',
-                        fontSize: '13px',
-                        marginBottom: '5px'
-                    }}>{UPLOAD_NEW_DATASET_MSG}</FormLabel>
-                    <FormControl
-                        encType="multipart/form-data"
-                        required
-                        variant="standard"
-                        style={{ padding: '0 25px' }}>
-                        <TextField
-                            inputRef={textFieldRef}
-                            variant="standard"
-                            name="file-upload"
-                            type="file"
-                            onChange={handleFileChange}
-                            inputProps={{
-                                accept: ".csv",
-                                disableunderline: "true",
-                                style: {
-                                    border: 'dotted 1px #b5b5b5',
-                                    padding: '12px',
-                                    borderRadius: 0
-                                }
-                            }}
-                        />
-                    </FormControl>
-                    <FormLabel sx={{ margin: '5px 25px', fontStyle: 'italic', fontSize: 12 }} className={classes["text-upload"]}>{UPLOAD_NEW_DATASET_FILE_HELPER_MSG}</FormLabel>
-                    <FormControl required variant="standard" style={{ margin: '35px 25px 10px 25px' }}>
-                        <ComboBoxWithInputText
-                            ref={comboInputTextRef}
-                            options={datasets}
-                            label="As new dataset / Add to existing dataset"
-                            handleInputChange={handleInputChange}
-                            placeholder={UPLOAD_NEW_DATASET_NAME_PLACEHOLER_MSG}
-                            noOptionsPlaceholder="No datasets available"
-                            error={datasetNameError} 
-                            helperText={datasetNameError}
-                        />
-                    </FormControl>
-                    <div style={{ width: '100%', display: 'flex', justifyContent: 'right', marginTop: '20px' }}>
-                       <ButtonIBM onClick={handleLoadDoc} text="Upload" className={ buttonIBMClasses[`button-ibm${datasetNameError ? '-disabled' : ''}`]} />
-                    </div>
-                </FormControl>
-            </div>
-            <Backdrop
-        sx={{ color: '#fff' }}
-        open={backdropOpen}
-      >
+  return (
+    <Box className={classes.wrapper} style={{ borderRight: "none" }}>
+      <DeleteDatasetModal
+        open={deleteDatasetModalOpen}
+        setOpen={setDeleteDatasetModalOpen}
+        value={datasetName}
+        handleDeleteDataset={handleDeleteDataset}
+        clearFields={clearFields}
+      />
+      <div className={classes.sleuth_header}>
+        <img alt="dataset" src={data_icon} style={{ width: "16px", height: "16px", marginRight: "6px" }} />
+        <h4 style={{ fontSize: "16px", fontWeight: "400", margin: 0, paddingTop: "2px" }}>New Documents</h4>
+      </div>
+      <div style={{ borderRight: "solid 1px #8d8d8d" }}>
+        <h2 style={{ padding: "25px", margin: 0 }}>Upload</h2>
+        <FormControl variant="standard" sx={{ m: 0, width: "350px" }}>
+          <FormLabel
+            style={{
+              paddingLeft: "25px",
+              paddingRight: "25px",
+              fontSize: "13px",
+              marginBottom: "5px",
+            }}
+          >
+            {UPLOAD_NEW_DATASET_MSG}
+          </FormLabel>
+          <FormControl encType="multipart/form-data" required variant="standard" style={{ padding: "0 25px" }}>
+            <TextField
+              inputRef={textFieldRef}
+              variant="standard"
+              name="file-upload"
+              type="file"
+              onChange={handleFileChange}
+              inputProps={{
+                accept: ".csv",
+                disableunderline: "true",
+                style: {
+                  border: "dotted 1px #b5b5b5",
+                  padding: "12px",
+                  borderRadius: 0,
+                },
+              }}
+            />
+          </FormControl>
+          <FormLabel sx={{ margin: "5px 25px", fontStyle: "italic", fontSize: 12 }} className={classes["text-upload"]}>
+            {UPLOAD_NEW_DATASET_FILE_HELPER_MSG}
+          </FormLabel>
+          <FormControl required variant="standard" style={{ margin: "35px 25px 10px 25px" }}>
+            <ComboBoxWithInputText
+              ref={comboInputTextRef}
+              options={datasets}
+              label="As new dataset / Add to existing dataset"
+              handleInputChange={handleInputChange}
+              placeholder={UPLOAD_NEW_DATASET_NAME_PLACEHOLER_MSG}
+              noOptionsPlaceholder="No datasets available"
+              error={datasetNameError}
+              helperText={datasetNameError}
+            />
+          </FormControl>
+          <div style={{ width: "100%", display: "flex", justifyContent: "right", marginTop: "20px" }}>
+            <ButtonIBM
+              disabled={!deleteButtonEnabled}
+              style={{ marginRight: "1px" }}
+              onClick={() => setDeleteDatasetModalOpen(true)}
+              className={buttonIBMClasses["button-ibm"]}
+              text="Delete"
+            />
+            <ButtonIBM
+              onClick={handleLoadDoc}
+              text="Upload"
+              className={buttonIBMClasses[`button-ibm${datasetNameError ? "-disabled" : ""}`]}
+            />
+          </div>
+        </FormControl>
+      </div>
+      <Backdrop sx={{ color: "#fff" }} open={backdropOpen}>
         <CircularProgress color="inherit" />
       </Backdrop>
-        </Box>
-
-    );
+    </Box>
+  );
 };
 
 export default LoadDocumentForm;

--- a/frontend/src/modules/Workspace-config/index.jsx
+++ b/frontend/src/modules/Workspace-config/index.jsx
@@ -27,7 +27,6 @@ import useNewWorkspace from "../../customHooks/useNewWorkspace";
 import { useLogOut } from "../../customHooks/useLogOut";
 import useExistWorkspace from "../../customHooks/useExistWorkspace";
 import workspace_logo from "../../assets/workspace-config/tag--edit.svg";
-import { toast } from "react-toastify";
 import useBackdrop from "../../customHooks/useBackdrop";
 import { useWorkspaceId } from "../../customHooks/useWorkspaceId";
 import { SystemVersion } from "../../components/version/SystemVersion";

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -121,7 +121,6 @@ export const parseElements = (
   unparsedElements: UnparsedElement[],
   curCategoryId: number | null
 ): { elements: ElementsDict } => {
-  
   let elements: ElementsDict = {};
 
   unparsedElements.forEach((element) => {
@@ -222,4 +221,17 @@ export const getWorkspaceId = (): string => {
  */
 export const addBOMCharacter = (text: string): string => {
   return BOMCharacter + text;
-}
+};
+
+/**
+ * Given a list, return a string with the list elements separated by commas and an 'and' character before the last one
+ */
+export const stringifyList = (list: string[]): string => {
+  if (list.length === 1) return list[0];
+  else {
+    let res = "";
+    if (list.length > 2) list.slice(0, -2).forEach((c) => (res += `'${c}', `));
+    res += `'${list.slice(-2, -1)[0]}' and '${list.slice(-1)[0]}'`;
+    return res;
+  }
+};

--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -197,6 +197,26 @@ def add_documents(dataset_name):
             os.remove(os.path.join(temp_dir, temp_file_name))
 
 
+@main_blueprint.route("/datasets/<dataset_name>/used_by", methods=['GET'])
+@login_if_required
+def get_workspaces_by_dataset_name(dataset_name):
+    res = {'used_by': curr_app.orchestrator_api.get_workspaces_by_dataset_name(dataset_name)}
+    return jsonify(res)
+
+
+@main_blueprint.route("/datasets/<dataset_name>", methods=['DELETE'])
+@login_if_required
+def delete_dataset(dataset_name):
+    """
+    This call permanently deletes the given dataset. If the dataset is used by one or more workspaces, those will be deleted too, along with all the categories, user
+    labels and models.
+
+    :param dataset_name:
+    """
+    res = curr_app.orchestrator_api.delete_dataset(dataset_name)
+    return jsonify(res)
+
+
 """
 Workspace endpoints. Each workspace is associated with a particular dataset at creation time.
 """
@@ -288,7 +308,6 @@ def load_dataset(workspace_id):
     """
     executor.submit(curr_app.orchestrator_api.preload_dataset, workspace_id)
     return jsonify({"success": True})
-
 
 
 """

--- a/label_sleuth/data_access/data_access_api.py
+++ b/label_sleuth/data_access/data_access_api.py
@@ -272,7 +272,7 @@ class DataAccessApi(object, metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def delete_dataset(self, dataset_name):
+    def delete_dataset(self, dataset_name: str):
         """
         Delete dataset by name
         :param dataset_name:

--- a/label_sleuth/data_access/file_based/file_based_data_access.py
+++ b/label_sleuth/data_access/file_based/file_based_data_access.py
@@ -441,12 +441,12 @@ class FileBasedDataAccess(DataAccessApi):
 
     def get_all_dataset_names(self) -> List[str]:
         """
-        :return: a list of all available datset names
+        :return: a list of all available dataset names
         """
         path = self._get_datasets_base_dir()
         return [name for name in os.listdir(path) if os.path.isdir(os.path.join(path, name))]
 
-    def delete_dataset(self, dataset_name):
+    def delete_dataset(self, dataset_name: str):
         """
         Delete dataset by name
         :param dataset_name:

--- a/label_sleuth/orchestrator/orchestrator_api.py
+++ b/label_sleuth/orchestrator/orchestrator_api.py
@@ -111,6 +111,37 @@ class OrchestratorApi:
             except Exception as e:
                 logging.exception(f"error clearing saved labels for workspace '{workspace_id}'")
                 raise e
+    
+    def get_workspaces_by_dataset_name(self, dataset_name: str):
+        workspaces_ids = []
+        for workspace_id in self.list_workspaces():
+            if self.get_dataset_name(workspace_id) == dataset_name:
+                workspaces_ids.append(workspace_id)
+        return workspaces_ids
+
+
+    def delete_dataset(self, dataset_name: str):
+        """
+        Delete a given workspace
+        :param workspace_id:
+        """
+        logging.info(f"Deleting dataset '{dataset_name}'")
+        
+
+        workspaces_to_delete = self.get_workspaces_by_dataset_name(dataset_name)
+        for workspace_id in workspaces_to_delete:
+            self.delete_workspace(workspace_id)
+        
+        # delete dataset
+        self.data_access.delete_dataset(dataset_name)
+
+        res = {
+            'deleted_dataset': dataset_name,
+            'deleted_workspace_ids': workspaces_to_delete
+        }
+
+        return res
+
 
     def workspace_exists(self, workspace_id: str) -> bool:
         return self.orchestrator_state.workspace_exists(workspace_id)


### PR DESCRIPTION
I've started working on [this issue](https://github.com/label-sleuth/label-sleuth/issues/409). First, to improve this first version:
- Improve the wording.
- Make the text that explain that some workspaces may be deleted too to call more the attention of the user. - Maybe we can add a subsequent modal after the first one in case workspaces are going to be deleted.
- Backend changes:
  - add two endpoints: /datasets/<dataset_name>/used_by (GET) , which returns a list of the workspaces that use a particular dataset and /datasets/<dataset_name> (DELETE)
  - add two method to the OrchestratorApi : get_workspaces_by_dataset_name()  and delete_dataset() , delete_dataset calls get_workspaces_by_dataset_name()  to delete workspaces if those are using the dataset that is going to be deleted and then delete them. Finally it calls a new data_access  method to delete the dataset.
  - add delete_dataset  to data_access (file based) . It removes the folder returned by self._get_dataset_base_dir(dataset_name) which now is data_access_dups/<dataset_name> .
  - I know that locks are used when working with workspaces, should we implement a similar mechanism when working with datasets?