### PR TITLE
Global toast messages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@
 import "./App.css";
 
 import { useEffect, useState } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import { Login } from "./modules/Login/index";
 import { WorkspaceConfig } from "./modules/Workspace-config";
 import { Workplace } from "./modules/Workplace";
@@ -36,10 +36,21 @@ import { useWorkspaceId } from "./customHooks/useWorkspaceId";
 import { fetchVersion } from "./modules/Workplace/redux";
 import { useCheckSystemHealth } from "./customHooks/useCheckSystemHealth";
 import { ErrorDetailsDialog } from "./error/ErrorDetailsDialog";
+import { useNotification } from "./utils/notification";
 
 const AppRoutes = () => {
   const { authenticated, authenticationEnabled } = useAuthentication();
   const { workspaceId } = useWorkspaceId();
+  let location = useLocation();
+  const { closeAllNotifications } = useNotification();
+
+  useEffect(() => {
+    closeAllNotifications();
+  }, [location.pathname, closeAllNotifications]);
+
+  useEffect(() => {
+    closeAllNotifications();
+  }, [location.pathname, closeAllNotifications]);
 
   return (
     <Routes>

--- a/frontend/src/components/combobox/ComboBoxWithInputText.tsx
+++ b/frontend/src/components/combobox/ComboBoxWithInputText.tsx
@@ -15,61 +15,66 @@
 
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
-import Stack from "@mui/material/Stack";
-import { forwardRef } from "react";
 
 interface ComboBoxWithInputTextProps {
   options: {
     dataset_id: string;
   }[];
-  handleInputChange: (e: React.FormEvent, newVal?: string) => void;
+  handleInputChange: (e: React.FormEvent, newVal: string | null) => void;
   label: React.ReactNode;
   placeholder: string;
   error: boolean;
   helperText: React.ReactNode;
+  value: string;
 }
 
-export const ComboBoxWithInputText = forwardRef(
-  ({ options, handleInputChange, label, placeholder, error, helperText }: ComboBoxWithInputTextProps, ref) => {
-    return (
-      <Stack spacing={3} sx={{ width: "100%" }}>
-        <Autocomplete
-          onInputChange={handleInputChange}
-          id="free-solo-demo"
-          freeSolo
-          options={options && options.map((option) => option.dataset_id)}
-          renderInput={(params) => (
-            <TextField
-              inputRef={ref}
-              onChange={handleInputChange}
-              {...params}
-              label={label}
-              variant="standard"
-              InputLabelProps={{
-                ...params.InputLabelProps,
-                shrink: true,
-                style: {
-                  fontSize: "18px",
-                  marginTop: "-8px",
-                },
-              }}
-              InputProps={{
-                ...params.InputProps,
-                sx: {
-                  background: "#fff",
-                  padding: "6px 10px",
-                  "&::placeholder": {
-                    color: "#b5b5b5"
-                  }
-                },
-              }}
-              placeholder={placeholder}
-              error={error ? true : false}
-              helperText={helperText}
-            />
-          )}
+export const ComboBoxWithInputText = ({
+  options,
+  handleInputChange,
+  label,
+  placeholder,
+  error,
+  helperText,
+  value,
+}: ComboBoxWithInputTextProps) => {
+  console.log(`value: ${value}`)
+
+  return (
+    <Autocomplete
+      freeSolo
+      options={options && options.map((option) => option.dataset_id)}
+      onChange={handleInputChange}
+      onInputChange={handleInputChange}
+      value={value || null}
+      inputValue={value}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          variant="standard"
+          InputLabelProps={{
+            ...params.InputLabelProps,
+            shrink: true,
+            style: {
+              fontSize: "18px",
+              marginTop: "-8px",
+            },
+          }}
+          InputProps={{
+            ...params.InputProps,
+            sx: {
+              background: "#fff",
+              padding: "6px 10px",
+              "&::placeholder": {
+                color: "#b5b5b5",
+              },
+            },
+          }}
+          placeholder={placeholder}
+          error={error ? true : false}
+          helperText={helperText}
         />
-      </Stack>
-    );
-  }
-);
+      )}
+    />
+  );
+};

--- a/frontend/src/const.ts
+++ b/frontend/src/const.ts
@@ -94,8 +94,12 @@ export const newDataCreatedMessage = (
   numsentences: number
 ) =>
   `The new dataset '${name}' has been created with ${numDocs} documents and ${numsentences} text entries.`;
+
+
 export const CATEGORY_NAME_MAX_CHARS = 100;
-export const WRONG_INPUT_NAME_LENGTH = `Name may be max ${CATEGORY_NAME_MAX_CHARS} characters long`;
+export const DATASET_NAME_MAX_CHARS = 30;
+
+export const WRONG_INPUT_NAME_LENGTH = (maxLength: number) => `Name may be max ${maxLength} characters long`;
 export const WRONG_INPUT_NAME_BAD_CHARACTER_NO_SPACES = `Name may only contain English characters, digits and underscores`;
 export const WRONG_INPUT_NAME_BAD_CHARACTER = `Name may only contain English characters, digits, underscores and spaces`;
 export const REGEX_LETTER_NUMBERS_UNDERSCORE = /^[a-zA-Z0-9_]*$/;

--- a/frontend/src/const.ts
+++ b/frontend/src/const.ts
@@ -93,7 +93,7 @@ export const newDataCreatedMessage = (
   numDocs: number,
   numsentences: number
 ) =>
-  `The new dataset ${name} has been created with ${numDocs} documents and ${numsentences} text entries.`;
+  `The new dataset '${name}' has been created with ${numDocs} documents and ${numsentences} text entries.`;
 export const CATEGORY_NAME_MAX_CHARS = 100;
 export const WRONG_INPUT_NAME_LENGTH = `Name may be max ${CATEGORY_NAME_MAX_CHARS} characters long`;
 export const WRONG_INPUT_NAME_BAD_CHARACTER_NO_SPACES = `Name may only contain English characters, digits and underscores`;

--- a/frontend/src/customHooks/useLoadDoc.ts
+++ b/frontend/src/customHooks/useLoadDoc.ts
@@ -138,6 +138,9 @@ export const useLoadDoc = ({ toastId }: UseLoadDocProps) => {
         });
         clearFields();
       }
+      else {
+        closeNotification(uploadDatasetToastId) // error toast notification will be displayed
+      }
     })
   };
 

--- a/frontend/src/customHooks/useNewModelNotifications.ts
+++ b/frontend/src/customHooks/useNewModelNotifications.ts
@@ -38,7 +38,11 @@ export const useNewModelNotifications = ({
   const dispatch = useAppDispatch();
   const prevModelVersion = usePrevious(modelVersion);
   const newModelVersionAvailable = React.useMemo(
-    () => prevModelVersion !== null && modelVersion !== null && modelVersion > -1 && prevModelVersion !== modelVersion,
+    () =>
+      prevModelVersion !== null &&
+      modelVersion !== null &&
+      modelVersion > -1 &&
+      prevModelVersion !== modelVersion,
     [prevModelVersion, modelVersion]
   );
   const { notify } = useNotification();
@@ -47,12 +51,24 @@ export const useNewModelNotifications = ({
     if (curCategory !== null && newModelVersionAvailable === true) {
       shouldFireConfetti && fire();
       if (modelVersion === 1) {
-        notify("A new model is available!", { type: toast.TYPE.SUCCESS, toastId: "toast-new-model" });
+        notify("A new model is available!", {
+          type: toast.TYPE.SUCCESS,
+          toastId: "toast-new-model",
+        });
         notify("There are new suggestions for labeling!", {
           type: toast.TYPE.SUCCESS,
           toastId: "toast-new-suggestions-for-labelling",
+          autoClose: 5000,
         });
       }
     }
-  }, [notify, curCategory, newModelVersionAvailable, modelVersion, fire, dispatch, shouldFireConfetti]);
+  }, [
+    notify,
+    curCategory,
+    newModelVersionAvailable,
+    modelVersion,
+    fire,
+    dispatch,
+    shouldFireConfetti,
+  ]);
 };

--- a/frontend/src/customHooks/useNewWorkspace.ts
+++ b/frontend/src/customHooks/useNewWorkspace.ts
@@ -26,6 +26,7 @@ import {
   WRONG_INPUT_NAME_LENGTH,
   WRONG_INPUT_NAME_BAD_CHARACTER_NO_SPACES,
   REGEX_LETTER_NUMBERS_UNDERSCORE,
+  CATEGORY_NAME_MAX_CHARS,
 } from "../const";
 import { useWorkspaceId } from "./useWorkspaceId";
 import { useAppDispatch, useAppSelector } from "./useRedux";
@@ -49,7 +50,7 @@ const useNewWorkspace = (toastId: string) => {
     let val = (e.target as HTMLInputElement).value;
     let error = "";
     if (val.length > 30) {
-      error = WRONG_INPUT_NAME_LENGTH;
+      error = WRONG_INPUT_NAME_LENGTH(CATEGORY_NAME_MAX_CHARS);
     } else if (!val.match(REGEX_LETTER_NUMBERS_UNDERSCORE)) {
       error = WRONG_INPUT_NAME_BAD_CHARACTER_NO_SPACES;
     }

--- a/frontend/src/customHooks/useNotifyNewModelTraining.ts
+++ b/frontend/src/customHooks/useNotifyNewModelTraining.ts
@@ -3,7 +3,7 @@ import { useNotification } from "../utils/notification";
 import { useAppSelector } from "./useRedux";
 import { toast } from "react-toastify";
 
-const toastId = "model_is_training";
+const toastId = "model_is_training_toast";
 
 /**
  * This custom hooks notifies the user when a model is being trained.
@@ -24,7 +24,7 @@ export const useNotifyNewModelTraining = () => {
     if (nextModelShouldBeTraining) {
       notify(
         "Training a new model in the background, meanwhile you can continue labeling.",
-        { toastId: toastId, type: toast.TYPE.INFO }
+        { toastId: toastId, type: toast.TYPE.INFO, autoClose: 5000 }
       );
     } else {
       closeNotification(toastId);

--- a/frontend/src/error/useNotifyError.tsx
+++ b/frontend/src/error/useNotifyError.tsx
@@ -42,7 +42,7 @@ export const useNotifyError = ({ open, setOpen }: useNotifyErrorProps) => {
       notify(toNotify, {
         autoClose: false,
         type: toast.TYPE.ERROR,
-        toastId: error.type,
+        toastId: `${error.type}_error_toast`,
         draggable: false,
       });
     }

--- a/frontend/src/modules/Workplace/information/FileTransferLabels/index.tsx
+++ b/frontend/src/modules/Workplace/information/FileTransferLabels/index.tsx
@@ -322,7 +322,7 @@ export const DownloadModelDialog = ({
   ];
 
   useEffect(() => {
-    const toastId = "downloading-model-notification";
+    const toastId = "downloading_model_toast";
     if (downloadingModel) {
       notify("Preparing the model (this can take up to a minute).", {
         toastId,

--- a/frontend/src/modules/Workplace/upperbar/Modal/CreateCategoryModal.tsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/CreateCategoryModal.tsx
@@ -74,6 +74,7 @@ export const CreateCategoryModal = ({ open, setOpen }: CreateCategoryModalProps)
         notify(`The category '${newCategoryName}' has been created`, {
           type: toast.TYPE.SUCCESS,
           autoClose: 5000,
+          toastId: 'category_created_toast'
         });
       }
     });

--- a/frontend/src/modules/Workplace/upperbar/Modal/CreateCategoryModal.tsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/CreateCategoryModal.tsx
@@ -50,7 +50,7 @@ export const CreateCategoryModal = ({ open, setOpen }: CreateCategoryModalProps)
     let text = e.target.value;
     if (text) {
       if (text.length > CATEGORY_NAME_MAX_CHARS) {
-        setCategoryNameError(WRONG_INPUT_NAME_LENGTH);
+        setCategoryNameError(WRONG_INPUT_NAME_LENGTH(CATEGORY_NAME_MAX_CHARS));
       }  else
         setCategoryNameError("");
     } else {

--- a/frontend/src/modules/Workplace/upperbar/Modal/DeleteCategoryModal.tsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/DeleteCategoryModal.tsx
@@ -43,6 +43,7 @@ export const DeleteCategoryModal = ({ open, setOpen }: DeleteCategoryModalProps)
         notify(`The category ${curCategoryName} has been deleted`, {
           type: toast.TYPE.SUCCESS,
           autoClose: 5000,
+          toastId: "category_deleted_toast"
         });
       }
     });

--- a/frontend/src/modules/Workplace/upperbar/Modal/EditCategoryModal.tsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/EditCategoryModal.tsx
@@ -79,6 +79,7 @@ export const EditCategoryModal = ({ open, setOpen }: EditCategoryModalProps) => 
         notify("The category name has been successfully edited", {
           type: toast.TYPE.SUCCESS,
           autoClose: 5000,
+        toastId: "category_edited_toast"
         });
       }
     });

--- a/frontend/src/modules/Workplace/upperbar/Modal/EditCategoryModal.tsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/EditCategoryModal.tsx
@@ -89,7 +89,7 @@ export const EditCategoryModal = ({ open, setOpen }: EditCategoryModalProps) => 
     let text = e.target.value;
     if (text) {
       if (text.length > CATEGORY_NAME_MAX_CHARS) {
-        setCategoryNameError(WRONG_INPUT_NAME_LENGTH);
+        setCategoryNameError(WRONG_INPUT_NAME_LENGTH(CATEGORY_NAME_MAX_CHARS));
       } else
         setCategoryNameError("");
     } else {

--- a/frontend/src/modules/Workspace-config/DeleteDatasetModal.tsx
+++ b/frontend/src/modules/Workspace-config/DeleteDatasetModal.tsx
@@ -102,7 +102,7 @@ export const DeleteDatasetModal = ({
             >
               {workspacesUsingDataset !== null &&
                 workspacesUsingDataset.map((workspace, i) => (
-                  <ListItem sx={{ pb: 0, pt: 0 }}>
+                  <ListItem sx={{ pb: 0, pt: 0 }} key={i}>
                     <DialogContentText>{workspace}</DialogContentText>
                   </ListItem>
                 ))}

--- a/frontend/src/modules/Workspace-config/LoadDocumentForm.tsx
+++ b/frontend/src/modules/Workspace-config/LoadDocumentForm.tsx
@@ -37,15 +37,15 @@ interface LoadDocumentFormProps {
   handleLoadDoc: () => void;
   handleFileChange: (e: React.FormEvent) => void;
   datasets: Dataset[];
-  handleInputChange: (e: React.FormEvent, newVal?: string) => void;
-  textFieldRef: React.MutableRefObject<HTMLInputElement | undefined>;
-  comboInputTextRef: React.MutableRefObject<HTMLInputElement | undefined>;
+  handleInputChange: (e: React.FormEvent, newVal: string | null) => void;
+  fileInputRef: React.MutableRefObject<HTMLInputElement | undefined>;
   backdropOpen: boolean;
   datasetNameError: string;
   deleteButtonEnabled: boolean;
   datasetName: string;
   handleDeleteDataset: () => void;
   clearFields: () => void;
+  file: File | null;
 }
 
 const LoadDocumentForm = ({
@@ -53,14 +53,13 @@ const LoadDocumentForm = ({
   handleFileChange,
   datasets,
   handleInputChange,
-  textFieldRef,
-  comboInputTextRef,
   backdropOpen,
   datasetNameError,
   deleteButtonEnabled,
   datasetName,
   handleDeleteDataset,
   clearFields,
+  fileInputRef,
 }: LoadDocumentFormProps) => {
   const [deleteDatasetModalOpen, setDeleteDatasetModalOpen] =
     React.useState(false);
@@ -110,7 +109,7 @@ const LoadDocumentForm = ({
             style={{ padding: "0 25px" }}
           >
             <TextField
-              inputRef={textFieldRef}
+              inputRef={fileInputRef}
               variant="standard"
               name="file-upload"
               type="file"
@@ -138,12 +137,11 @@ const LoadDocumentForm = ({
             style={{ margin: "35px 25px 10px 25px" }}
           >
             <ComboBoxWithInputText
-              ref={comboInputTextRef}
+              value={datasetName}
               options={datasets}
               label="As new dataset / Add to existing dataset"
               handleInputChange={handleInputChange}
               placeholder={UPLOAD_NEW_DATASET_NAME_PLACEHOLER_MSG}
-              //noOptionsPlaceholder="No datasets available"
               error={datasetNameError !== ""}
               helperText={datasetNameError}
             />

--- a/frontend/src/modules/Workspace-config/workspaceConfigSlice.ts
+++ b/frontend/src/modules/Workspace-config/workspaceConfigSlice.ts
@@ -155,9 +155,7 @@ export const workspacesSlice = createSlice({
         state.uploadingDataset = true;
       })
       .addCase(addDocuments.fulfilled, (state, action: PayloadAction<AddedDataset>) => {
-        state.datasetAdded = action.payload;
         state.uploadingDataset = false;
-        state.isDocumentAdded = true;
       });
   },
 });

--- a/frontend/src/modules/Workspace-config/workspaceConfigSlice.ts
+++ b/frontend/src/modules/Workspace-config/workspaceConfigSlice.ts
@@ -14,12 +14,29 @@
 */
 
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
-import { BASE_URL, GET_WORKSPACES_API, GET_DATASETS_API, CREATE_WORKSPACE_API, ADD_DOCUMENTS_API } from "../../config";
+import {
+  BASE_URL,
+  GET_WORKSPACES_API,
+  GET_DATASETS_API,
+  CREATE_WORKSPACE_API,
+  ADD_DOCUMENTS_API,
+} from "../../config";
 import { client } from "../../api/client";
-import { AddedDataset, CreatedWorkspace, CreateWorkspaceBody, Dataset, WorkspaceConfigSliceState } from "../../global";
+import {
+  AddedDataset,
+  CreatedWorkspace,
+  CreateWorkspaceBody,
+  Dataset,
+  WorkspaceConfigSliceState,
+} from "../../global";
 
 const initialState: WorkspaceConfigSliceState = {
-  datasetAdded: { dataset_name: "", num_docs: -1, num_sentences: -1, workspaces_to_update: [] },
+  datasetAdded: {
+    dataset_name: "",
+    num_docs: -1,
+    num_sentences: -1,
+    workspaces_to_update: [],
+  },
   isWorkspaceAdded: false,
   workspaces: [],
   active_workspace: "",
@@ -33,10 +50,13 @@ const getWorkspaces_url = `${BASE_URL}/${GET_WORKSPACES_API}`;
 const getDatasets_url = `${BASE_URL}/${GET_DATASETS_API}`;
 const createWorkset_url = `${BASE_URL}/${CREATE_WORKSPACE_API}`;
 
-export const getWorkspaces = createAsyncThunk("workspaces/getWorkspaces", async () => {
-  const { data } = await client.get(getWorkspaces_url);
-  return data;
-});
+export const getWorkspaces = createAsyncThunk(
+  "workspaces/getWorkspaces",
+  async () => {
+    const { data } = await client.get(getWorkspaces_url);
+    return data;
+  }
+);
 
 export const createWorkspace = createAsyncThunk<
   CreatedWorkspace,
@@ -46,41 +66,54 @@ export const createWorkspace = createAsyncThunk<
   return data;
 });
 
-export const deleteWorkspace = createAsyncThunk<string, { workspaceId: string }>(
-  `workspaces/deleteWorkspace`,
-  async ({ workspaceId }) => {
-    const url = `${BASE_URL}/workspace/${encodeURIComponent(workspaceId)}`;
-    const { data } = await client.delete(url);
-    return data.workspace_id;
-  }
-);
+export const deleteWorkspace = createAsyncThunk<
+  string,
+  { workspaceId: string }
+>(`workspaces/deleteWorkspace`, async ({ workspaceId }) => {
+  const url = `${BASE_URL}/workspace/${encodeURIComponent(workspaceId)}`;
+  const { data } = await client.delete(url);
+  return data.workspace_id;
+});
 
-export const deleteDataset = createAsyncThunk<{deleted_dataset: string, deleted_workspace_ids: string[]}, { datasetName: string }>(
-  `workspaces/deleteDataset`,
-  async ({ datasetName }) => {
-    const url = `${getDatasets_url}/${encodeURIComponent(datasetName)}`;
-    const { data } = await client.delete(url);
-    return data;
-  }
-);
+export const deleteDataset = createAsyncThunk<
+  { deleted_dataset: string; deleted_workspace_ids: string[] },
+  { datasetName: string | null }
+>(`workspaces/deleteDataset`, async ({ datasetName }) => {
+  if (datasetName === null) return;
+  const url = `${getDatasets_url}/${encodeURIComponent(datasetName)}`;
+  const { data } = await client.delete(url);
+  return data;
+});
 
 export const addDocuments = createAsyncThunk<AddedDataset, FormData>(
   `workspaces/getDatasets/dataset_name/addDocuments`,
   async (formData) => {
     const dataset_name = formData.get("dataset_name");
     const url = `${getDatasets_url}/${dataset_name}/${ADD_DOCUMENTS_API}`;
-    const { data } = await client.post(url, formData, { stringifyBody: false, omitContentType: true });
+    const { data } = await client.post(url, formData, {
+      stringifyBody: false,
+      omitContentType: true,
+    });
     return data;
   }
 );
 
-export const getDatasets = createAsyncThunk("workspaces/getDatasets", async () => {
-  const { data } = await client.get(getDatasets_url);
-  return data;
-});
+export const getDatasets = createAsyncThunk(
+  "workspaces/getDatasets",
+  async () => {
+    const { data } = await client.get(getDatasets_url);
+    return data;
+  }
+);
 
-export const getWorkspacesByDatasetName = createAsyncThunk<{ workspaceIds: string[] }, string>("workspaces/getWorkspacesByDatasetName", async (datasetName) => {
-  const { data } = await client.get(`${getDatasets_url}/${encodeURIComponent(datasetName)}/used_by`);
+export const getWorkspacesByDatasetName = createAsyncThunk<
+  { workspaceIds: string[] },
+  string | null
+>("workspaces/getWorkspacesByDatasetName", async (datasetName) => {
+  if (datasetName === null) return;
+  const { data } = await client.get(
+    `${getDatasets_url}/${encodeURIComponent(datasetName)}/used_by`
+  );
   return data;
 });
 
@@ -98,20 +131,26 @@ export const workspacesSlice = createSlice({
       .addCase(getWorkspaces.pending, (state) => {
         state.loading = true;
       })
-      .addCase(getWorkspaces.fulfilled, (state, { payload }: PayloadAction<{ workspaces: string[] }>) => {
-        state.loading = false;
-        state.workspaces = payload.workspaces;
-      })
+      .addCase(
+        getWorkspaces.fulfilled,
+        (state, { payload }: PayloadAction<{ workspaces: string[] }>) => {
+          state.loading = false;
+          state.workspaces = payload.workspaces;
+        }
+      )
       .addCase(getWorkspaces.rejected, (state) => {
         state.loading = false;
       })
       .addCase(getDatasets.pending, (state) => {
         state.loading = true;
       })
-      .addCase(getDatasets.fulfilled, (state, { payload }: PayloadAction<{ datasets: Dataset[] }>) => {
-        state.loading = false;
-        state.datasets = payload.datasets;
-      })
+      .addCase(
+        getDatasets.fulfilled,
+        (state, { payload }: PayloadAction<{ datasets: Dataset[] }>) => {
+          state.loading = false;
+          state.datasets = payload.datasets;
+        }
+      )
       .addCase(getDatasets.rejected, (state) => {
         state.loading = false;
       })
@@ -131,32 +170,66 @@ export const workspacesSlice = createSlice({
       .addCase(deleteWorkspace.pending, (state) => {
         state.loading = true;
       })
-      .addCase(deleteWorkspace.fulfilled, (state, action: PayloadAction<string>) => {
-        const deletedWorkspaceId = action.payload;
-        state.loading = false;
-        state.workspaces = state.workspaces.filter((w) => w !== deletedWorkspaceId);
-      })
+      .addCase(
+        deleteWorkspace.fulfilled,
+        (state, action: PayloadAction<string>) => {
+          const deletedWorkspaceId = action.payload;
+          state.loading = false;
+          state.workspaces = state.workspaces.filter(
+            (w) => w !== deletedWorkspaceId
+          );
+        }
+      )
       .addCase(deleteDataset.rejected, (state) => {
         state.loading = false;
       })
       .addCase(deleteDataset.pending, (state) => {
         state.loading = true;
       })
-      .addCase(deleteDataset.fulfilled, (state, action: PayloadAction<{deleted_dataset: string, deleted_workspace_ids: string[]}>) => {
-        const {deleted_dataset: deletedDatasetName, deleted_workspace_ids: deletedWorkspaceIds} = action.payload;
-        state.loading = false;
-        state.datasets = state.datasets.filter((d) => d.dataset_id !== deletedDatasetName);
-        state.workspaces = state.workspaces.filter((w) => !deletedWorkspaceIds.includes(w));
-      })
+      .addCase(
+        deleteDataset.fulfilled,
+        (
+          state,
+          action: PayloadAction<{
+            deleted_dataset: string;
+            deleted_workspace_ids: string[];
+          }>
+        ) => {
+          const {
+            deleted_dataset: deletedDatasetName,
+            deleted_workspace_ids: deletedWorkspaceIds,
+          } = action.payload;
+          state.loading = false;
+          state.datasets = state.datasets.filter(
+            (d) => d.dataset_id !== deletedDatasetName
+          );
+          state.workspaces = state.workspaces.filter(
+            (w) => !deletedWorkspaceIds.includes(w)
+          );
+        }
+      )
       .addCase(addDocuments.rejected, (state) => {
         state.uploadingDataset = false;
       })
       .addCase(addDocuments.pending, (state) => {
         state.uploadingDataset = true;
       })
-      .addCase(addDocuments.fulfilled, (state, action: PayloadAction<AddedDataset>) => {
-        state.uploadingDataset = false;
-      });
+      .addCase(
+        addDocuments.fulfilled,
+        (state, action: PayloadAction<AddedDataset>) => {
+          state.uploadingDataset = false;
+          if (
+            state.datasets.filter(
+              (d) => d.dataset_id === action.payload.dataset_name
+            ).length === 0
+          ) {
+            state.datasets = [
+              ...state.datasets,
+              { dataset_id: action.payload.dataset_name },
+            ];
+          }
+        }
+      );
   },
 });
 export const { clearState } = workspacesSlice.actions;

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -16,7 +16,12 @@
 import "@testing-library/jest-dom";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { modelUpdateExample, workspacesExample, datasetsExample, categoriesExample } from "./utils/test-utils";
+import {
+  modelUpdateExample,
+  workspacesExample,
+  datasetsExample,
+  categoriesExample,
+} from "./utils/test-utils";
 
 jest.setTimeout(10000);
 
@@ -56,39 +61,54 @@ const handlers = [
       })
     );
   }),
-  rest.delete("/workspace/:workspace_id/category/:category_id", (req, res, ctx) => {
-    return res(
-      ctx.delay(),
-      ctx.json({
-        category_id: "26",
-        workspace_id: "workspace_id",
-      })
-    );
-  }),
-  rest.put("/workspace/:workspace_id/category/:category_id", (req, res, ctx) => {
-    const { category_name, category_description } = req.body as Record<string, any>;
-    return res(
-      ctx.delay(),
-      ctx.json({
-        category_id: "26",
-        category_description,
-        category_name,
-        workspace_id: "workspace_id",
-      })
-    );
+  rest.delete(
+    "/workspace/:workspace_id/category/:category_id",
+    (req, res, ctx) => {
+      return res(
+        ctx.delay(),
+        ctx.json({
+          category_id: "26",
+          workspace_id: "workspace_id",
+        })
+      );
+    }
+  ),
+  rest.put(
+    "/workspace/:workspace_id/category/:category_id",
+    (req, res, ctx) => {
+      const { category_name, category_description } = req.body as Record<
+        string,
+        any
+      >;
+      return res(
+        ctx.delay(),
+        ctx.json({
+          category_id: "26",
+          category_description,
+          category_name,
+          workspace_id: "workspace_id",
+        })
+      );
+    }
+  ),
+  rest.get("/version", (_, res, ctx) => {
+    return res(ctx.delay(), ctx.json({ source: "git", version: "v0.11.7" }));
   }),
 ];
 
 const server = setupServer(...handlers);
 
 beforeAll(() => {
-  window.sessionStorage.setItem("workspaceId", JSON.stringify("workspace_id"));
   server.listen();
 });
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.setItem("workspaceId", JSON.stringify("workspace_id"));
+})
 
 afterEach(() => server.resetHandlers());
 
 afterAll(() => {
   server.close();
-  window.localStorage.clear();
 });

--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -188,7 +188,6 @@ def add_documents(dataset_name):
         df = pd.read_csv(csv_data).rename(columns=lambda x: x.strip())
 
         if not text_column in df.columns:
-            logging.info("I am here brooo")
             raise NoTextColumnException("The csv file doesn't have a text column")
 
         temp_dir = os.path.join(curr_app.config["output_dir"], "temp", "csv_upload")


### PR DESCRIPTION
This PR improves the toast notification managment by:
- using the session storage to store which toasts are currently being displayed.
- use a naming convention for all toast ids: `[descriptive_name]_toast`.
- adapt tests.
- improve add documents toast notifications.
- set auto close to 5 seconds in the model is training toast notification.