### PR TITLE
Adapt labeling status message and model checks conditions

### DIFF
--- a/frontend/src/customHooks/useWorkspaceState.ts
+++ b/frontend/src/customHooks/useWorkspaceState.ts
@@ -81,6 +81,9 @@ const useWorkspaceState = () => {
 
   React.useEffect(() => {
     // update the model version when the category changes (if any)
+    // reset the model status chech attemps count so when a category changes
+    // we check several time whether there is a model
+    // (possibly zero shot) is training
     if (mode === WorkspaceMode.BINARY && curCategory !== null) {
       dispatch(checkModelUpdate());
       dispatch(cleanEvaluationState());

--- a/frontend/src/featureFlags/featureFlagsSlice.ts
+++ b/frontend/src/featureFlags/featureFlagsSlice.ts
@@ -26,8 +26,9 @@ const initialState: FeatureFlagsSliceState = {
   mainPanelElementsPerPage: -1,
   rightToLeft: false,
   maxDatasetLength: -1,
-  multiclassPerClassLabelingThreshold: -1,
   binaryFirstModelPositiveThreshold: -1,
+  multiclassPerClassLabelingThreshold: -1,
+  multiclassZeroShotFirstModel: false,
 };
 
 export const fetchFeatureFlags = createAsyncThunk("workspaces/fetchFeatureFlags", async () => {
@@ -56,8 +57,9 @@ export const featureFlagsSlice = createSlice({
           sidebarPanelElementsPerPage: featureFlags["sidebar_panel_elements_per_page"],
           rightToLeft: featureFlags["right_to_left"],
           maxDatasetLength: featureFlags["max_dataset_length"],
-          multiclassPerClassLabelingThreshold: featureFlags["multiclass_per_class_labeling_threshold"],
           binaryFirstModelPositiveThreshold: featureFlags["binary_first_model_positive_threshold"],
+          multiclassPerClassLabelingThreshold: featureFlags["multiclass_per_class_labeling_threshold"],
+          multiclassZeroShotFirstModel: featureFlags["multiclass_zero_shot_first_model"],
         };
       })
       .addCase(fetchFeatureFlags.rejected, (state, { error }) => {

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -75,7 +75,7 @@ interface PanelState {
   elements: ElementsDict | null;
   hitCount: number | null;
   page: number;
-  filters?: {[key: string]: string | null}
+  filters?: { [key: string]: string | null };
 }
 
 interface MainPanelState extends PanelState {
@@ -87,7 +87,7 @@ interface ContractingLabelsPanelState extends PanelState {
 }
 
 interface PositivePredictionsPanelState extends PanelState {
-  stats: {[key:string]: {count: number, fraction: number}}
+  stats: { [key: string]: { count: number; fraction: number } };
 }
 
 interface EvaluationPanelState extends PanelState {
@@ -166,8 +166,9 @@ interface FeatureFlagsSliceState {
   mainPanelElementsPerPage: number;
   rightToLeft: boolean;
   maxDatasetLength: number;
-  multiclassPerClassLabelingThreshold: number;
   binaryFirstModelPositiveThreshold: number;
+  multiclassPerClassLabelingThreshold: number;
+  multiclassZeroShotFirstModel: boolean;
 }
 
 interface CustomizableUITextSliceState {
@@ -282,7 +283,7 @@ interface FetchPanelElementsParams {
   useLastSearchString?: boolean;
   // value is used to filter user label and model prediction by category in mcmode and by true or neg label en bmode
   // in bmode, value is 'true' or 'false'
-  value?: string
+  value?: string;
 }
 
 interface ErrorResponse {

--- a/frontend/src/modules/Workplace/information/LabelCountPanelMCMode.tsx
+++ b/frontend/src/modules/Workplace/information/LabelCountPanelMCMode.tsx
@@ -21,6 +21,9 @@ export const LabelCountPanelMCMode = () => {
   const activePanelId = useAppSelector(
     (state) => state.workspace.panels.activePanelId
   );
+  const nextModelShouldBeTraining = useAppSelector(
+    (state) => state.workspace.nextModelShouldBeTraining
+  );
   const multiclassPerClassLabelingThreshold = useAppSelector(
     (state) => state.featureFlags.multiclassPerClassLabelingThreshold
   );
@@ -127,14 +130,16 @@ export const LabelCountPanelMCMode = () => {
                       overflow: "hidden",
                       whiteSpace: "nowrap",
                       textOverflow: "ellipsis",
-                      maxWidth: "80%"
+                      maxWidth: "80%",
                     }}
                   >
                     {c.category_name}
                   </Typography>
                   <Stack direction={"row"} alignItems={"center"}>
-                    {(labelCount as { [key: string]: number })[c.category_id.toString()] <
-                    multiclassPerClassLabelingThreshold ? (
+                    {(labelCount as { [key: string]: number })[
+                      c.category_id.toString()
+                    ] < multiclassPerClassLabelingThreshold &&
+                    !nextModelShouldBeTraining ? (
                       <WarningAmberIcon
                         sx={{
                           color: "gray",

--- a/frontend/src/modules/Workplace/information/index.tsx
+++ b/frontend/src/modules/Workplace/information/index.tsx
@@ -62,7 +62,7 @@ interface WorkspaceInfoProps {
  */
 export const WorkspaceInfo = ({
   setTutorialOpen,
-  checkModelInterval = 5000,
+  checkModelInterval = 3000,
   shouldFireConfetti = true,
 }: WorkspaceInfoProps) => {
   const curCategory = useAppSelector((state) => state.workspace.curCategory);

--- a/frontend/src/modules/Workplace/upperbar/Modal/CategoriesMenu.tsx
+++ b/frontend/src/modules/Workplace/upperbar/Modal/CategoriesMenu.tsx
@@ -70,6 +70,7 @@ import {
   deleteCategory,
   editCategory,
   nonDeletedCategoriesSelector,
+  resetModelStatusCheckAttempts,
 } from "../../redux";
 import { isFulfilled } from "@reduxjs/toolkit";
 import { toast } from "react-toastify";
@@ -523,6 +524,7 @@ export const CategoriesMenu = ({ open, setOpen }: CategoriesMenuProps) => {
           actionResults.length > 0 &&
           actionResults.every((actionResults) => isFulfilled(actionResults))
         ) {
+          dispatch(resetModelStatusCheckAttempts());
           notify(
             `The ${
               newCategories.length > 1 ? "categories" : "category"
@@ -556,6 +558,7 @@ export const CategoriesMenu = ({ open, setOpen }: CategoriesMenuProps) => {
           actionResults.length > 0 &&
           actionResults.every((actionResults) => isFulfilled(actionResults))
         ) {
+          dispatch(resetModelStatusCheckAttempts());
           notify(
             `The ${
               editedCategories.length > 1 ? "categories" : "category"

--- a/label_sleuth/app.py
+++ b/label_sleuth/app.py
@@ -1571,6 +1571,7 @@ def get_feature_flags():
         "right_to_left": curr_app.config['CONFIGURATION'].language.right_to_left,
         "max_dataset_length": curr_app.config['CONFIGURATION'].max_dataset_length,
         "multiclass_per_class_labeling_threshold": curr_app.config['CONFIGURATION'].multiclass_flow.per_class_labeling_threshold,
+        "multiclass_zero_shot_first_model": curr_app.config['CONFIGURATION'].multiclass_flow.zero_shot_first_model,
         "binary_first_model_positive_threshold": curr_app.config['CONFIGURATION'].binary_flow.first_model_positive_threshold
 
     }


### PR DESCRIPTION
Adapt the logic behind deciding when to make /status endpoint calls.