### PR TITLE
Fix delete workspace

### DIFF
--- a/label_sleuth/data_access/file_based/file_based_data_access.py
+++ b/label_sleuth/data_access/file_based/file_based_data_access.py
@@ -449,7 +449,7 @@ class FileBasedDataAccess(DataAccessApi):
         :param workspace_id:
         :param dataset_name:
         """
-        self.labels_in_memory.pop(workspace_id)
+        if workspace_id in self.labels_in_memory: del self.labels_in_memory[workspace_id]
         labels_file = self._get_workspace_labels_dump_filename(workspace_id, dataset_name)
         if os.path.isfile(labels_file):
             os.remove(labels_file)


### PR DESCRIPTION
Deleting a workspace fails if workspace's labels are not in memory.